### PR TITLE
ADD mmio_console printf method:

### DIFF
--- a/src/kernel.zig
+++ b/src/kernel.zig
@@ -1,6 +1,7 @@
 const mmio_console = @import("./mmio_console.zig");
 
 fn init_console(c: *mmio_console.Buffer) void {
+    c.init_writer();
     c.set_font_color(mmio_console.Color.white);
     c.set_view_bottom();
 }
@@ -9,6 +10,6 @@ var console = mmio_console.Buffer{};
 
 export fn kernel_main() void {
 	init_console(&console);
-    console.putstr("hello, world");
+    console.printf("hello, {}", .{42});
     console.view();
 }


### PR DESCRIPTION
This pull request simply introduces a new printf method available in BufferN for writing formatted strings to buffers.

Adding:
- A BufferWriter type, (a simple std.io.Writer, with the Buffer.write method as callback)
- A writer field on the BufferN struct
- An init_writer method to init the writer according to the current Buffer instance
- A printf method using the writer to format a string and pass it to the Buffer.write method