### PR TITLE
REWORK build system for zig 13.0:

### DIFF
--- a/build/Step/DirectoryDependency.zig
+++ b/build/Step/DirectoryDependency.zig
@@ -5,7 +5,7 @@ const AddDirectoryStep = struct {
     run_step: *std.Build.Step.Run,
     dir_path: std.Build.LazyPath,
 
-    fn make(step: *std.Build.Step, _: *std.Progress.Node) !void {
+    fn make(step: *std.Build.Step, _: std.Progress.Node) !void {
         const self: *AddDirectoryStep = @alignCast(@fieldParentPtr("step", step));
         const b = step.owner;
 

--- a/build/disk_image.zig
+++ b/build/disk_image.zig
@@ -5,7 +5,7 @@ const addDirectoryDependency = @import("Step/DirectoryDependency.zig").addDirect
 
 pub fn install_iso_folder(context: *BuildContext) void {
     context.install_iso_folder = context.builder.addInstallDirectory(.{
-        .source_dir = .{ .path = context.iso_source_dir },
+        .source_dir = .{ .cwd_relative = context.iso_source_dir },
         .install_dir = .prefix,
         .install_subdir = "iso",
     });
@@ -18,11 +18,11 @@ pub fn build_disk_image(context: *BuildContext) void {
         "-o",
     });
     const iso_file = context.grub.addOutputFileArg("kfs.iso");
-    context.grub.addDirectoryArg(.{ .path = "zig-out/iso" });
+    context.grub.addDirectoryArg(.{ .cwd_relative = "zig-out/iso" });
 
     const directory_step = addDirectoryDependency(
         context.grub,
-        .{ .path = "zig-out/iso" },
+        .{ .cwd_relative = "zig-out/iso" },
     );
 
     directory_step.step.dependOn(&context.install_iso_folder.step);

--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -1,7 +1,10 @@
 FROM alpine
 
-RUN echo 'https://dl-cdn.alpinelinux.org/alpine/edge/community' >> /etc/apk/repositories
+RUN echo "https://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories
+RUN echo "https://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
+RUN echo "https://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
+
 
 RUN apk update
 
-RUN apk add zig make grub mtools xorriso grub-bios grub-dev grub-efi xz wget
+RUN apk add make grub mtools xorriso grub-bios grub-dev grub-efi xz wget llvm lld zig

--- a/build/kernel.zig
+++ b/build/kernel.zig
@@ -16,7 +16,7 @@ pub fn build_executable(context: *BuildContext) void {
 
     context.kernel = context.builder.addExecutable(.{
         .name = context.name,
-        .root_source_file = .{ .path = "src/boot.zig" },
+        .root_source_file = .{ .cwd_relative = "src/boot.zig" },
         .target = context.builder.resolveTargetQuery(CrossTarget{
             .cpu_arch = Target.Cpu.Arch.x86,
             .os_tag = Target.Os.Tag.freestanding,
@@ -32,12 +32,14 @@ pub fn build_executable(context: *BuildContext) void {
     context.build_options.addOption(bool, "ci", context.ci);
     context.kernel.root_module.addOptions("build_options", context.build_options);
 
-    const colors_module = context.builder.createModule(.{ .root_source_file = .{ .path = "./src/misc/colors.zig" } });
+    const colors_module = context.builder.createModule(
+        .{ .root_source_file = .{ .cwd_relative = "./src/misc/colors.zig" } },
+    );
     context.kernel.root_module.addImport("colors", colors_module);
 
-    context.kernel.addIncludePath(std.Build.LazyPath{ .path = "./src/c_headers/" });
+    context.kernel.addIncludePath(std.Build.LazyPath{ .cwd_relative = "./src/c_headers/" });
 
-    context.kernel.setLinkerScriptPath(.{ .path = "src/linker.ld" });
+    context.kernel.setLinkerScriptPath(.{ .cwd_relative = "src/linker.ld" });
     context.kernel.entry = .{ .symbol_name = "_entry" };
 
     context.install_kernel = context.builder.addInstallArtifact(context.kernel, .{


### PR DESCRIPTION
Fix LazyPaths in build scripts, using 'cwd_relative' field instead of previously 'path'.
Fix zig installation step in Dockerfile.