### PR TITLE
add generic syscall interface

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -46,12 +46,16 @@ pub fn build(b: *Builder) !void {
     // Build steps
     const kernel = @import("build/kernel.zig").build_executable(&context);
     const themes = @import("build/themes.zig").install_themes(&context);
+    const syscall_table = @import("build/syscall_table.zig").build_syscall_table_step(&context);
     const install_disk_image = @import("build/iso.zig").build_iso(&context, kernel);
     const uninstall_themes = @import("build/themes.zig").uninstall_themes(&context);
+    const uninstall_syscall_table = @import("build/syscall_table.zig").uninstall_syscall_table_step(&context);
     _ = @import("build/qemu.zig").add_step_run(&context, install_disk_image);
 
     // Dependencies
     kernel.step.dependOn(&themes.step);
+    kernel.step.dependOn(syscall_table);
     b.getInstallStep().dependOn(&install_disk_image.step);
-    b.getUninstallStep().dependOn(&uninstall_themes.step);
+    b.getUninstallStep().dependOn(uninstall_themes);
+    b.getUninstallStep().dependOn(uninstall_syscall_table);
 }

--- a/build/syscall_table.zig
+++ b/build/syscall_table.zig
@@ -1,0 +1,43 @@
+const std = @import("std");
+
+const BuildContext = @import("../build.zig").BuildContext;
+
+const syscall_dir = "src/syscall";
+const output_file_path = "src/syscall_table.zig";
+
+fn build_syscall_table(step: *std.Build.Step, prog_node: std.Progress.Node) anyerror!void {
+    _ = prog_node;
+    var output_file = try std.fs.cwd().createFile(output_file_path, .{});
+    defer output_file.close();
+
+    var dir = std.fs.cwd().openDir(syscall_dir, .{ .iterate = true }) catch return;
+    defer dir.close();
+
+    var iter = try dir.walk(step.owner.allocator);
+    defer iter.deinit();
+
+    while (try iter.next()) |entry| {
+        if (entry.kind != .file) continue;
+        try output_file.writer().print("pub const {s} = @import(\"{s}/{s}\");\n", .{
+            std.fs.path.stem(entry.basename), std.fs.path.basename(syscall_dir), entry.path,
+        });
+    }
+}
+
+pub fn build_syscall_table_step(context: *BuildContext) *std.Build.Step {
+    const syscall_step = context.builder.allocator.create(std.Build.Step) catch @panic("OOM");
+    syscall_step.* = std.Build.Step.init(.{
+        .id = .custom,
+        .name = "create syscall table",
+        .owner = context.builder,
+        .makeFn = build_syscall_table,
+    });
+    return syscall_step;
+}
+
+pub fn uninstall_syscall_table_step(context: *BuildContext) *std.Build.Step {
+    const uninstall_theme = context.builder.addSystemCommand(&.{ "rm", output_file_path });
+    uninstall_theme.setName("uninstall syscall table");
+    context.builder.getUninstallStep().dependOn(&uninstall_theme.step);
+    return &uninstall_theme.step;
+}

--- a/build/themes.zig
+++ b/build/themes.zig
@@ -13,12 +13,12 @@ pub fn install_themes(context: *BuildContext) *Step.Run {
     return themes;
 }
 
-pub fn uninstall_themes(context: *BuildContext) *Step.Run {
+pub fn uninstall_themes(context: *BuildContext) *Step {
     const uninstall_theme = context.builder.addSystemCommand(&.{
         "make",
         "theme_clean",
         "--no-print-directory",
     });
     uninstall_theme.setName("uninstall themes");
-    return uninstall_theme;
+    return &uninstall_theme.step;
 }

--- a/src/boot.zig
+++ b/src/boot.zig
@@ -77,6 +77,8 @@ export fn init(eax: u32, ebx: u32) callconv(.C) void {
 
     @import("./drivers/acpi/acpi.zig").init();
 
+    @import("syscall.zig").init();
+
     if (!@import("build_options").ci) {
         kernel.main();
     } else {

--- a/src/drivers/pit/pit.zig
+++ b/src/drivers/pit/pit.zig
@@ -143,7 +143,7 @@ pub fn init_channel(comptime channel: SelectChannel, frequency: u32) void {
     pit_logger.debug("{s} initialized", .{@tagName(channel)});
 }
 
-pub fn pit_handler(_: interrupts.InterruptFrame) callconv(.C) void {
+pub fn pit_handler(_: *interrupts.InterruptFrame) callconv(.C) void {
     ch0_ticks +%= 1;
     pic.ack(.Timer);
 }

--- a/src/errno.zig
+++ b/src/errno.zig
@@ -1,0 +1,111 @@
+const ft = @import("ft/ft.zig");
+
+pub const Errno = error{
+    E2BIG,
+    EACCES,
+    EADDRINUSE,
+    EADDRNOTAVAIL,
+    EAFNOSUPPORT,
+    EAGAIN,
+    EALREADY,
+    EBADF,
+    EBADMSG,
+    EBUSY,
+    ECANCELED,
+    ECHILD,
+    ECONNABORTED,
+    ECONNREFUSED,
+    ECONNRESET,
+    EDEADLK,
+    EDESTADDRREQ,
+    EDOM,
+    EDQUOT,
+    EEXIST,
+    EFAULT,
+    EFBIG,
+    EHOSTUNREACH,
+    EIDRM,
+    EILSEQ,
+    EINPROGRESS,
+    EINTR,
+    EINVAL,
+    EIO,
+    EISCONN,
+    EISDIR,
+    ELOOP,
+    EMFILE,
+    EMLINK,
+    EMSGSIZE,
+    EMULTIHOP,
+    ENAMETOOLONG,
+    ENETDOWN,
+    ENETRESET,
+    ENETUNREACH,
+    ENFILE,
+    ENOBUFS,
+    ENODATA,
+    ENODEV,
+    ENOENT,
+    ENOEXEC,
+    ENOLCK,
+    ENOLINK,
+    ENOMEM,
+    ENOMSG,
+    ENOPROTOOPT,
+    ENOSPC,
+    ENOSR,
+    ENOSTR,
+    ENOSYS,
+    ENOTCONN,
+    ENOTDIR,
+    ENOTEMPTY,
+    ENOTRECOVERABLE,
+    ENOTSOCK,
+    ENOTSUP,
+    ENOTTY,
+    ENXIO,
+    EOPNOTSUPP,
+    EOVERFLOW,
+    EOWNERDEAD,
+    EPERM,
+    EPIPE,
+    EPROTO,
+    EPROTONOSUPPORT,
+    EPROTOTYPE,
+    ERANGE,
+    EROFS,
+    ESPIPE,
+    ESRCH,
+    ESTALE,
+    ETIME,
+    ETIMEDOUT,
+    ETXTBSY,
+    EWOULDBLOCK,
+    EXDEV,
+};
+
+pub fn is_in_set(e: anytype, comptime s: type) bool {
+    @setEvalBranchQuota(10_000);
+    return switch (e) {
+        inline else => |ce| comptime b: {
+            const errors = @typeInfo(s).ErrorSet orelse return false;
+            for (errors) |err| {
+                if (ft.mem.eql(u8, err.name, @errorName(ce))) break :b true;
+            }
+            break :b false;
+        },
+    };
+}
+
+pub fn error_num(e: Errno) usize {
+    @setEvalBranchQuota(10_000);
+    return switch (e) {
+        inline else => |ce| comptime b: {
+            const errors = @typeInfo(Errno).ErrorSet orelse unreachable;
+            for (errors, 1..) |err, n| {
+                if (ft.mem.eql(u8, err.name, @errorName(ce))) break :b n;
+            }
+            unreachable;
+        },
+    };
+}

--- a/src/memory.zig
+++ b/src/memory.zig
@@ -49,7 +49,7 @@ pub var physicalMemory: MultipoolAllocator = undefined;
 
 const InterruptFrame = @import("interrupts.zig").InterruptFrame;
 
-fn GPE_handler(frame: InterruptFrame) callconv(.C) void {
+fn GPE_handler(frame: *InterruptFrame) callconv(.C) void {
     logger.err("general protection fault 0b{b:0>32}", .{frame.code});
 }
 

--- a/src/memory/virtual_space.zig
+++ b/src/memory/virtual_space.zig
@@ -12,7 +12,7 @@ const RegionSet = @import("region_set.zig").RegionSet;
 
 const InterruptFrame = @import("../interrupts.zig").InterruptFrame;
 
-fn page_fault_handler(frame: InterruptFrame) callconv(.C) void {
+fn page_fault_handler(frame: *InterruptFrame) callconv(.C) void {
     const ErrorType = packed struct(u32) {
         present: bool,
         type: enum(u1) {

--- a/src/shell/ci/shell.zig
+++ b/src/shell/ci/shell.zig
@@ -7,7 +7,7 @@ const interrupts = @import("../../interrupts.zig");
 pub const Shell = @import("../Shell.zig").Shell(@import("builtins.zig"));
 pub var com_port_1: Serial = Serial.init(.com_port_1);
 
-fn pic_handler(_: interrupts.InterruptFrame) callconv(.C) void {
+fn pic_handler(_: *interrupts.InterruptFrame) callconv(.C) void {
     pic.ack(.COM1);
 }
 

--- a/src/syscall.zig
+++ b/src/syscall.zig
@@ -1,0 +1,37 @@
+const interrupts = @import("interrupts.zig");
+const tty = @import("./tty/tty.zig");
+const ft = @import("ft/ft.zig");
+const std = @import("std");
+const log = @import("ft/ft.zig").log;
+const errno = @import("errno.zig");
+
+const syscall_logger = log.scoped(.syscall);
+
+// Todo: Maybe found a better name for this enum
+// /!\ these syscalls are dummy ones for the example
+pub const Code = enum(u8) {
+    Sleep = 0,
+};
+
+pub fn syscall_handler(fr: *interrupts.InterruptFrame) callconv(.C) void {
+    const code: Code = std.meta.intToEnum(Code, fr.eax) catch {
+        syscall_logger.debug("Unknown call ({d})", .{fr.eax});
+        fr.ebx = errno.error_num(errno.Errno.ENOSYS);
+        return;
+    };
+    if (switch (code) {
+        .Sleep => @import("syscall/sleep.zig").sys_sleep(fr.ebx),
+        // else => syscall_logger.debug("not implemented yet ({d})", .{@intFromEnum(sys_num)}),
+    }) |v| {
+        fr.eax = v;
+        fr.ebx = 0;
+    } else |e| {
+        if (errno.is_in_set(e, errno.Errno)) {
+            fr.ebx = errno.error_num(e);
+        } else syscall_logger.err("unhandled error: {s}", .{@errorName(e)});
+    }
+}
+
+pub fn init() void {
+    interrupts.set_system_gate(0x80, interrupts.Handler.create(syscall_handler, false));
+}

--- a/src/syscall.zig
+++ b/src/syscall.zig
@@ -2,16 +2,98 @@ const interrupts = @import("interrupts.zig");
 const tty = @import("./tty/tty.zig");
 const ft = @import("ft/ft.zig");
 const std = @import("std");
+const syscall_table = @import("syscall_table.zig");
 const log = @import("ft/ft.zig").log;
 const errno = @import("errno.zig");
 
 const syscall_logger = log.scoped(.syscall);
 
+pub fn syscall_enum(comptime T: type) type {
+    const decls: []const std.builtin.Type.Declaration = @typeInfo(T).Struct.decls;
+    comptime var enumFields: [decls.len]std.builtin.Type.EnumField = undefined;
+    for (decls, enumFields[0..]) |d, *f| {
+        f.name = d.name;
+        f.value = @field(T, d.name).Id;
+    }
+    return @Type(.{ .Enum = .{
+        .tag_type = usize,
+        .fields = enumFields[0..],
+        .decls = &.{},
+        .is_exhaustive = true,
+    } });
+}
+
 // Todo: Maybe found a better name for this enum
 // /!\ these syscalls are dummy ones for the example
-pub const Code = enum(u8) {
-    Sleep = 0,
-};
+pub const Code = syscall_enum(syscall_table); // todo implement in ft
+
+fn get_fn_proto_tuple(comptime proto: std.builtin.Type.Fn) type {
+    comptime var fields: [proto.params.len]std.builtin.Type.StructField = undefined;
+
+    for (proto.params, fields[0..], 0..) |p, *f, i| {
+        f.* = .{
+            .name = &.{'0' + i},
+            .type = p.type.?,
+            .default_value = null,
+            .is_comptime = false,
+            .alignment = @alignOf(p.type.?),
+        };
+    }
+    return @Type(.{ .Struct = .{
+        .layout = .auto,
+        .backing_integer = null,
+        .fields = fields[0..],
+        .decls = &.{},
+        .is_tuple = true,
+    } });
+}
+
+fn convert_param(comptime T: type, reg: usize) T {
+    if (@typeInfo(T) == .Pointer) {
+        return @ptrFromInt(reg);
+    } else {
+        return @bitCast(@as(
+            std.meta.Int(.unsigned, @bitSizeOf(T)),
+            @truncate(reg),
+        ));
+    }
+}
+
+fn convert_ret(comptime T: type, val: T) usize {
+    if (@typeInfo(T) == .Pointer) {
+        return @intFromPtr(val);
+    } else {
+        return @intCast(@as(
+            std.meta.Int(.unsigned, @bitSizeOf(T)),
+            @bitCast(val),
+        ));
+    }
+}
+
+fn call_syscall(comptime code: Code, fr: interrupts.InterruptFrame) !usize {
+    const do_fn = @field(syscall_table, @tagName(code)).do;
+    const proto: std.builtin.Type.Fn = @typeInfo(@TypeOf(do_fn)).Fn;
+
+    if (proto.params.len > 6)
+        @compileError("syscall cannot have more than 6 parameter: " ++ @tagName(code));
+
+    const TupleType = get_fn_proto_tuple(proto);
+    var tuple: TupleType = undefined;
+    const param_register = [_][]const u8{ "ebx", "ecx", "edx", "esi", "edi", "ebp" };
+    inline for (0..tuple.len) |i| {
+        const reg = @field(fr, param_register[i]);
+        tuple[i] = convert_param(@TypeOf(tuple[i]), reg);
+    }
+
+    const ret: proto.return_type.? = @call(.auto, do_fn, tuple);
+
+    if (ret) |v| {
+        return if (comptime @TypeOf(v) != void)
+            convert_ret(@TypeOf(v), v)
+        else
+            0;
+    } else |e| return e;
+}
 
 pub fn syscall_handler(fr: *interrupts.InterruptFrame) callconv(.C) void {
     const code: Code = std.meta.intToEnum(Code, fr.eax) catch {
@@ -20,16 +102,13 @@ pub fn syscall_handler(fr: *interrupts.InterruptFrame) callconv(.C) void {
         return;
     };
     if (switch (code) {
-        .Sleep => @import("syscall/sleep.zig").sys_sleep(fr.ebx),
-        // else => syscall_logger.debug("not implemented yet ({d})", .{@intFromEnum(sys_num)}),
+        inline else => |c| call_syscall(c, fr.*),
     }) |v| {
         fr.eax = v;
         fr.ebx = 0;
-    } else |e| {
-        if (errno.is_in_set(e, errno.Errno)) {
-            fr.ebx = errno.error_num(e);
-        } else syscall_logger.err("unhandled error: {s}", .{@errorName(e)});
-    }
+    } else |e| if (errno.is_in_set(e, errno.Errno)) {
+        fr.ebx = errno.error_num(e);
+    } else syscall_logger.err("unhandled error: {s}", .{@errorName(e)});
 }
 
 pub fn init() void {

--- a/src/syscall/sleep.zig
+++ b/src/syscall/sleep.zig
@@ -1,6 +1,7 @@
 const pit = @import("../drivers/pit/pit.zig");
 
-pub fn sys_sleep(ns: u32) !u8 {
+pub const Id = 1;
+
+pub fn do(ns: u32) !void {
     pit.sleep(ns);
-    return 0;
 }

--- a/src/syscall/sleep.zig
+++ b/src/syscall/sleep.zig
@@ -1,0 +1,6 @@
+const pit = @import("../drivers/pit/pit.zig");
+
+pub fn sys_sleep(ns: u32) !u8 {
+    pit.sleep(ns);
+    return 0;
+}

--- a/src/tty/keyboard.zig
+++ b/src/tty/keyboard.zig
@@ -141,7 +141,7 @@ pub fn kb_read() void {
 
 const InterruptFrame = @import("../interrupts.zig").InterruptFrame;
 
-pub fn handler(_: InterruptFrame) callconv(.C) void {
+pub fn handler(_: *InterruptFrame) callconv(.C) void {
     // frame.debug();
     const scan_code: u8 = ps2.get_data();
     const index: u8 = scan_code & SCANCODE_MASK_INDEX;


### PR DESCRIPTION
Add a generic syscall interface.

In order to register a new syscall, you only need to declare a new zig file inside the `./src/syscall/' folder, declaring a public `do`
 function taking up to 6 arguments, and a `const Id` variable defining the syscall id.
The syscall table / interface will be automatically generated during build stage and comptime.

You can find an example in the `./src/syscall/sleep.zig` file introduced in this commit.
https://github.com/shadokos/kfs/blob/1a5d2309d111489c478cb86b127e76b710a8120d/src/syscall/sleep.zig#L1-L7