### PR TITLE
refactor tasks

### DIFF
--- a/src/interrupts.zig
+++ b/src/interrupts.zig
@@ -243,7 +243,7 @@ comptime {
 
 pub fn ret_from_interrupt(frame: *InterruptFrame) callconv(.C) void {
     if (frame_stack == null)
-        frame_stack = @TypeOf(frame_stack.?).init(@import("memory.zig").physicalMemory.allocator());
+        frame_stack = @TypeOf(frame_stack.?).init(@import("memory.zig").smallAlloc.allocator());
     if (@import("userspace.poc.zig").get_next_signal()) |handler_ptr| {
         frame_stack.?.append(frame.*) catch @panic("todo");
         frame.iret.ip = @intFromPtr(handler_ptr);

--- a/src/kernel.zig
+++ b/src/kernel.zig
@@ -31,7 +31,7 @@ fn task2() u8 {
 
 pub fn main() void {
     const logger = @import("ft/ft.zig").log.scoped(.main);
-    task.TaskUnion.init_cache() catch @panic("Failed to initialized kernel_task cache");
+    task.TaskDescriptor.init_cache() catch @panic("Failed to initialized kernel_task cache");
 
     const kernel = task_set.create_task() catch @panic("c'est  la  panique 2");
 

--- a/src/memory/object_allocators/multipool_allocator.zig
+++ b/src/memory/object_allocators/multipool_allocator.zig
@@ -39,6 +39,7 @@ pub const MultipoolAllocator = struct {
                 name ++ "_" ++ cache_descriptions[i].name,
                 page_allocator,
                 cache_descriptions[i].size,
+                @alignOf(usize),
                 cache_descriptions[i].order,
             );
         }

--- a/src/memory/object_allocators/slab/slab.zig
+++ b/src/memory/object_allocators/slab/slab.zig
@@ -2,6 +2,7 @@ const printk = @import("../../../tty/tty.zig").printk;
 const Cache = @import("cache.zig").Cache;
 const BitMap = @import("../../../misc/bitmap.zig").BitMap;
 const Bit = @import("../../../misc/bitmap.zig").Bit;
+const ft = @import("../../../ft/ft.zig");
 
 pub const SlabState = enum {
     Empty,
@@ -33,7 +34,11 @@ pub const Slab = struct {
         const mem: [*]usize = @ptrFromInt(@intFromPtr(page) + @sizeOf(Slab));
         new.bitmap = BitMap.init(mem, cache.obj_per_slab);
 
-        const start = @intFromPtr(page) + @sizeOf(Slab) + new.bitmap.get_size();
+        const start = ft.mem.alignForward(
+            usize,
+            @intFromPtr(page) + @sizeOf(Slab) + new.bitmap.get_size(),
+            cache.align_obj,
+        );
         new.data = @as([*]?u16, @ptrFromInt(start))[0 .. cache.obj_per_slab * (cache.size_obj / @sizeOf(usize))];
 
         for (0..cache.obj_per_slab) |i| {

--- a/src/memory/regions.zig
+++ b/src/memory/regions.zig
@@ -28,6 +28,7 @@ pub const Region = struct {
             "regions",
             @import("../memory.zig").directPageAllocator.page_allocator(),
             @sizeOf(@This()),
+            @alignOf(@This()),
             4,
         );
     }

--- a/src/memory/virtual_space_allocator.zig
+++ b/src/memory/virtual_space_allocator.zig
@@ -45,6 +45,7 @@ pub const VirtualSpaceAllocator = struct {
                 "virtual_space_nodes",
                 @import("../memory.zig").directPageAllocator.page_allocator(),
                 @sizeOf(@This()),
+                @alignOf(@This()),
                 4,
             );
         }

--- a/src/shell/Shell.zig
+++ b/src/shell/Shell.zig
@@ -1,7 +1,7 @@
 const ft = @import("../ft/ft.zig");
 const token = @import("token.zig");
 const colors = @import("colors");
-const allocator = @import("../memory.zig").physicalMemory.allocator();
+const allocator = @import("../memory.zig").smallAlloc.allocator();
 
 pub const CmdError = error{ CommandNotFound, InvalidNumberOfArguments, InvalidParameter, OtherError };
 pub const Config = struct {

--- a/src/shell/ci/builtins.zig
+++ b/src/shell/ci/builtins.zig
@@ -16,7 +16,7 @@ pub fn kfuzz(shell: anytype, args: [][]u8) CmdError!void {
     var packet = Packet(void).init(shell.writer);
     packet.type = .Success;
     packet.err = if (utils.fuzz(
-        @import("../../memory.zig").physicalMemory.allocator(),
+        @import("../../memory.zig").smallAlloc.allocator(),
         shell.writer,
         nb,
         max_size,
@@ -38,7 +38,7 @@ pub fn vfuzz(shell: anytype, args: [][]u8) CmdError!void {
     var packet = Packet(void).init(shell.writer);
     packet.type = .Success;
     packet.err = if (utils.fuzz(
-        @import("../../memory.zig").virtualMemory.allocator(),
+        @import("../../memory.zig").bigAlloc.allocator(),
         shell.writer,
         nb,
         max_size,

--- a/src/shell/ci/packet.zig
+++ b/src/shell/ci/packet.zig
@@ -1,7 +1,7 @@
 const ft = @import("../../ft/ft.zig");
 const Shell = @import("shell.zig").Shell;
 
-const allocator = @import("../../memory.zig").physicalMemory.allocator();
+const allocator = @import("../../memory.zig").smallAlloc.allocator();
 
 pub fn Packet(comptime T: type) type {
     return struct {

--- a/src/shell/default/builtins.zig
+++ b/src/shell/default/builtins.zig
@@ -136,7 +136,7 @@ pub fn alloc_page(shell: anytype, args: [][]u8) CmdError!void {
 
 pub fn kmalloc(shell: anytype, args: [][]u8) CmdError!void {
     if (args.len != 2) return CmdError.InvalidNumberOfArguments;
-    var kmem = &@import("../../memory.zig").physicalMemory;
+    var kmem = &@import("../../memory.zig").smallAlloc;
     const nb = ft.fmt.parseInt(usize, args[1], 0) catch return CmdError.InvalidParameter;
     const obj: []u8 = kmem.alloc(u8, nb) catch {
         utils.print_error(shell, "Failed to allocate {d} bytes", .{nb});
@@ -148,7 +148,7 @@ pub fn kmalloc(shell: anytype, args: [][]u8) CmdError!void {
 pub fn kfree(shell: anytype, args: [][]u8) CmdError!void {
     if (args.len != 2) return CmdError.InvalidNumberOfArguments;
 
-    var kmem = &@import("../../memory.zig").physicalMemory;
+    var kmem = &@import("../../memory.zig").smallAlloc;
     const addr = ft.fmt.parseInt(usize, args[1], 0) catch return CmdError.InvalidParameter;
     if (!ft.mem.isAligned(addr, @sizeOf(usize))) {
         utils.print_error(shell, "0x{x} is not aligned", .{addr});
@@ -160,7 +160,7 @@ pub fn kfree(shell: anytype, args: [][]u8) CmdError!void {
 pub fn ksize(shell: anytype, args: [][]u8) CmdError!void {
     if (args.len != 2) return CmdError.InvalidNumberOfArguments;
 
-    var kmem = &@import("../../memory.zig").physicalMemory;
+    var kmem = &@import("../../memory.zig").smallAlloc;
     const addr = ft.fmt.parseInt(usize, args[1], 0) catch return CmdError.InvalidParameter;
     if (!ft.mem.isAligned(addr, @sizeOf(usize))) {
         utils.print_error(shell, "0x{x} is not aligned", .{addr});
@@ -176,7 +176,7 @@ pub fn ksize(shell: anytype, args: [][]u8) CmdError!void {
 pub fn krealloc(shell: anytype, args: [][]u8) CmdError!void {
     if (args.len != 3) return CmdError.InvalidNumberOfArguments;
 
-    var kmem = &@import("../../memory.zig").physicalMemory;
+    var kmem = &@import("../../memory.zig").smallAlloc;
     const addr = ft.fmt.parseInt(usize, args[1], 0) catch return CmdError.InvalidParameter;
     const new_size = ft.fmt.parseInt(usize, args[2], 0) catch return CmdError.InvalidParameter;
     if (!ft.mem.isAligned(addr, @sizeOf(usize))) {
@@ -255,7 +255,7 @@ pub fn kfuzz(shell: anytype, args: [][]u8) CmdError!void {
     ) catch return CmdError.InvalidParameter else 10000;
 
     return utils.fuzz(
-        @import("../../memory.zig").physicalMemory.allocator(),
+        @import("../../memory.zig").directMemory.allocator(),
         shell.writer,
         nb,
         max_size,
@@ -274,7 +274,7 @@ pub fn vfuzz(shell: anytype, args: [][]u8) CmdError!void {
     ) catch return CmdError.InvalidParameter else 10000;
 
     return utils.fuzz(
-        @import("../../memory.zig").virtualMemory.allocator(),
+        @import("../../memory.zig").bigAlloc.allocator(),
         shell.writer,
         nb,
         max_size,

--- a/src/shell/default/builtins.zig
+++ b/src/shell/default/builtins.zig
@@ -217,6 +217,7 @@ pub fn cache_create(_: anytype, args: [][]u8) CmdError!void {
 
         size,
         @truncate(order),
+        @alignOf(usize),
     ) catch {
         printk("Failed to create cache\n", .{});
         return CmdError.OtherError;

--- a/src/task/task.zig
+++ b/src/task/task.zig
@@ -12,6 +12,7 @@ const logger = @import("../ft/ft.zig").log.scoped(.task);
 const Errno = @import("../errno.zig").Errno;
 
 pub const TaskDescriptor = struct {
+    stack: [4096]u8 align(4096) = undefined, // todo
     pid: Pid,
     pgid: Pid,
 
@@ -38,6 +39,18 @@ pub const TaskDescriptor = struct {
     };
     pub const Pid = i32;
     pub const Self = @This();
+
+    pub var cache: *Cache = undefined;
+
+    pub fn init_cache() !void {
+        cache = try memory.globalCache.create(
+            "task_descriptor",
+            memory.directPageAllocator.page_allocator(),
+            @sizeOf(Self),
+            @alignOf(Self),
+            6,
+        );
+    }
 
     pub fn deinit(self: *Self) void {
         if (self.parent) |p| {
@@ -92,27 +105,9 @@ pub const TaskDescriptor = struct {
 
     pub fn wait_child(self: *Self, transition: status_informations.Status.Transition) Errno!?*Self {
         if (self.status_stack.top(transition)) |n| {
-            const descriptor: *Self = @fieldParentPtr("status_stack_process_node", n);
+            const descriptor: *Self = @alignCast(@fieldParentPtr("status_stack_process_node", n));
             return descriptor;
         } else return null;
-    }
-};
-
-pub const TaskUnion = struct {
-    task: TaskDescriptor,
-    stack: [2048 - @sizeOf(TaskDescriptor)]u8, // todo
-
-    const Self = @This();
-
-    pub var cache: *Cache = undefined;
-
-    pub fn init_cache() !void {
-        cache = try memory.globalCache.create(
-            "kernel_task",
-            memory.directPageAllocator.page_allocator(),
-            @sizeOf(TaskUnion),
-            4,
-        );
     }
 };
 
@@ -152,14 +147,13 @@ pub fn start_task(function: *const fn () u8) noreturn {
 
 pub fn spawn(function: *const fn () u8) !*TaskDescriptor {
     const descriptor = try task_set.create_task();
-    const taskUnion: *TaskUnion = @fieldParentPtr("task", descriptor);
     var is_parent: bool = false;
     const is_parent_ptr: *volatile bool = &is_parent;
     scheduler.checkpoint();
-    if (is_parent_ptr.*) {} else {
+    if (!is_parent_ptr.*) {
         is_parent_ptr.* = true;
         scheduler.set_current_task(descriptor);
-        cpu.set_esp(@as(usize, @intFromPtr(&taskUnion.stack)) + taskUnion.stack.len);
+        cpu.set_esp(@as(usize, @intFromPtr(&descriptor.stack)) + descriptor.stack.len);
         start_task(function);
     }
     return descriptor;

--- a/src/task/task.zig
+++ b/src/task/task.zig
@@ -116,22 +116,15 @@ pub const TaskUnion = struct {
     }
 };
 
-pub noinline fn switch_to_task_opts(prev: *TaskDescriptor, next: *TaskDescriptor, clone_stack: bool) void {
+pub noinline fn switch_to_task_opts(prev: *TaskDescriptor, next: *TaskDescriptor) void {
     asm volatile ("pushal");
     prev.esp = cpu.get_esp();
-    if (clone_stack) {
-        @memcpy(
-            @as([*]u8, @ptrCast(next))[@sizeOf(TaskDescriptor)..@sizeOf(TaskUnion)],
-            @as([*]u8, @ptrCast(prev))[@sizeOf(TaskDescriptor)..@sizeOf(TaskUnion)],
-        );
-        next.esp = prev.esp - @as(usize, @intFromPtr(prev)) + @as(usize, @intFromPtr(next));
-    }
     cpu.set_esp(next.esp);
     asm volatile ("popal");
 }
 
 pub fn switch_to_task(prev: *TaskDescriptor, next: *TaskDescriptor) void {
-    return switch_to_task_opts(prev, next, false);
+    return switch_to_task_opts(prev, next);
 }
 
 pub fn getpid() TaskDescriptor.Pid {

--- a/src/userspace.poc.zig
+++ b/src/userspace.poc.zig
@@ -7,7 +7,7 @@ const paging = @import("memory/paging.zig");
 export var task_stack: [32 * paging.page_size]u8 align(paging.page_size) = undefined;
 
 pub fn init_vm() !*VirtualSpace {
-    const vm = try memory.virtualMemory.allocator().create(VirtualSpace);
+    const vm = try memory.bigAlloc.allocator().create(VirtualSpace);
     try vm.init();
     try vm.add_space(0, paging.high_half / paging.page_size);
     try vm.add_space((paging.page_tables) / paging.page_size, 768);


### PR DESCRIPTION

- remove clone_stack thing

- add alignment support in slab allocator

- put stack directly in TaskDescriptor, get rid of TaskUnion

- make the multipool allocator stateful and create a second instance based on the virtually contiguous page allocator.
rename the old physicalMemory to SmallAlloc