### PR TITLE
FIX ACPI Initialization in ReleaseFast

### DIFF
--- a/src/drivers/pit/pit.zig
+++ b/src/drivers/pit/pit.zig
@@ -149,15 +149,18 @@ pub fn pit_handler(_: *interrupts.InterruptFrame) callconv(.C) void {
 }
 
 pub fn sleep_n_ticks(ticks: u64) void {
+    @setRuntimeSafety(true);
     const start = ch0_ticks;
     while (ch0_ticks - start < ticks) cpu.halt();
 }
 
 pub fn nano_sleep(ns: u64) void {
+    @setRuntimeSafety(true);
     sleep_n_ticks(ns / interval_ns);
 }
 
 pub fn sleep(ms: u64) void {
+    @setRuntimeSafety(true);
     sleep_n_ticks(ms * 1_000_000 / interval_ns);
 }
 


### PR DESCRIPTION
The exact cause is uncertain (I didn't check assembly generated), but due to aggressive optimizations, the PIT's ``sleep`` family of functions were broken when the kernel was built with the ``ReleaseFast`` mode leading to a complete freeze during the boot phase.

While the PIT handler and the ``ch0_ticks`` counter were functioning correctly and incrementing as expected with each tick, the issue seemed confined to the PIT's ``sleep`` family of functions, which failed to work properly in ``ReleaseFast``.

To resolve this issue, we can use the [@setRuntimeSafety](https://ziglang.org/documentation/master/#setRuntimeSafety) builtin:
- Applying it to ``sleep_n_ticks`` prevents the kernel from stalling during
  the ACPI initialization phase.
- Similarly, applying it to ``nano_sleep`` and ``sleep`` ensures the kernel does not hang when a TIMEOUT occurs during the ACPI initialization phase.

fix #169