### PR TITLE
FIX IRQs (#187 and #189)

### DIFF
--- a/src/interrupts.zig
+++ b/src/interrupts.zig
@@ -334,6 +334,12 @@ pub fn default_handler(
         }
         pub fn irq(_: *InterruptFrame) callconv(.C) void {
             const _id = pic.get_irq_from_interrupt_id(id);
+
+            // If the interrupt was a spurious interrupt,
+            // the ack_spurious_interrupt will keep track of the
+            // spurious interrupt amount since boot, and will return true.
+            // So we can ignore the interrupt then.
+            if (pic.ack_spurious_interrupt(@intFromEnum(_id))) return;
             pic.ack(_id);
             ft.log.scoped(.irq).err("{d} ({s}) unhandled", .{ @intFromEnum(_id), @tagName(_id) });
         }

--- a/src/shell/default/builtins.zig
+++ b/src/shell/default/builtins.zig
@@ -290,3 +290,9 @@ pub fn sleep(_: anytype, args: [][]u8) CmdError!void {
 pub fn userspace(_: anytype, _: [][]u8) CmdError!void {
     @import("../../userspace.poc.zig").switch_to_userspace();
 }
+
+pub fn spurious(_: anytype, _: [][]u8) CmdError!void {
+    const pic = @import("../../drivers/pic/pic.zig");
+    printk("Spurious master: {d}\n", .{pic.get_spurious_master()});
+    printk("Spurious slave: {d}\n", .{pic.get_spurious_slave()});
+}

--- a/src/shell/default/helpers.zig
+++ b/src/shell/default/helpers.zig
@@ -98,3 +98,11 @@ pub fn vfuzz() void {
         .usage = "vfuzz <n> [<max_size>]",
     });
 }
+
+pub fn spurious() void {
+    print_helper(Help{
+        .name = "spurious",
+        .description = "Show the amount of spurious interrupts since boot for both PIC master and slave",
+        .usage = null,
+    });
+}


### PR DESCRIPTION
## FIX slave PIC IRQs wrongly mapped in the IDT (df9e41319ddbf369193b1d67ed5b1949480ba1d4):

The IDT entries were not setup correctly for the slave PIC IRQs.
It was due to ``get_interrupt_id_from_irq`` in the pic driver which doesn't return the right interrupt id.

This commit also introduces an automatic management of the master ``IRQ.Slave`` when enabling / disabling IRQs of the slave PIC.

fix https://github.com/shadokos/kfs/issues/187

## ADD handle spurious interrupts (2188d12d3972d9d6c0b442b59cf388d5343258d6):

This commit introduces the management of spurious interrupts.

It introduces 2 new variables and their getter to keep track of spurious interrupts in the pic drivers: ``spurious_master: u32`` and ``spurious_slave: u32``.
These variables will be incremented according to whether the interrupt occurred on the master PIC or the slave PIC.

It also introduces a new method ``ack_spurious_interrupt`` to keep ``spurious_master`` and ``spurious_slave`` up-to-date when spurious interrupt occurs, and acknowledge the master if the spurious occurs on the slave.
If this method is called from a real interrupt, it won't do anything and return false.

Since now, the default IRQ handlers will call in any case the ``ack_spurious_interrupt``.

Finally, a shell builtin "spurious" is added to display the amount of spurious interrupts since boot for both master and slave PIC.

fix https://github.com/shadokos/kfs/issues/189