### PR TITLE
FIX make clean:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,12 +50,11 @@ fast: .optimize-ReleaseFast .bootloader-$(BOOTLOADER)
 
 .PHONY: clean
 clean:
-    # || true forces the makefile to ignore the error
-	$(ZIG) build uninstall $(BUILD_ARGS) || true
+	rm -rf .zig-cache
 
 .PHONY: fclean
 fclean: clean
-	rm -rf .zig-cache zig-out .optimize-* .bootloader-*
+	rm -rf .zig-out .optimize-* .bootloader-* kfs.iso
 
 .PHONY: format
 format:

--- a/build/Makefiles/Zig.mk
+++ b/build/Makefiles/Zig.mk
@@ -8,7 +8,7 @@ ifeq ($(shell which zig),)
     release: install_zig
     fast: install_zig
     format: install_zig
-    clean: uninstall_zig
+    fclean: uninstall_zig
 
     ZIG ?= $(ZIG_LOCAL)
 endif

--- a/build/syscall_table.zig
+++ b/build/syscall_table.zig
@@ -37,6 +37,5 @@ pub fn build_syscall_table_step(context: *BuildContext) *std.Build.Step {
 pub fn uninstall_syscall_table_step(context: *BuildContext) *std.Build.Step {
     const uninstall_theme = context.builder.addSystemCommand(&.{ "rm", output_file_path });
     uninstall_theme.setName("uninstall syscall table");
-    context.builder.getUninstallStep().dependOn(&uninstall_theme.step);
     return &uninstall_theme.step;
 }


### PR DESCRIPTION
## FIX build zig clean when using local version (f4e2a617bf0db4bfff3ca63b08297cac90862d86):
When make clean using a local version, the zig binary was removed before attempting to zig build uninstall.

## REWORK uninstall syscall table build step (1b973031df92d89075a850d6c963967b2be3c5b0):
Make the function only returns the uninstall step, and doesn't make the uninstall step depends on it anymore (the dependency is already made on build.zig).

## REWORK Makefile (d9da5598bf8b24ca45907fb865850886ad4ceb18):
This commit provides more consistent clean and fclean rules and removes (at least for now) the 'zig build uninstall' from the 'clean' rule since zig 0.14.0 more or less broke this feature.