### PR TITLE
Add wait_queue, ready_queue, semaphores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ src/tty/themes
 .bootloader-*
 themes
 zig-linux-x86_64-[0-9]*.[0-9]*.[0-9]*
+src/syscall_table.zig

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,11 @@ fast: .optimize-ReleaseFast .bootloader-$(BOOTLOADER)
 	rm -rf .bootloader-*
 	touch $@
 
+.PHONY: debug-server
+debug-server: debug
+	pkill -f 'qemu.* -[^ ]*s' || true
+	qemu-system-i386 -cdrom kfs.iso -s -S 1>/dev/null 2>/dev/null &
+
 .PHONY: clean
 clean:
 	rm -rf .zig-cache

--- a/src/drivers/pit/pit.zig
+++ b/src/drivers/pit/pit.zig
@@ -162,9 +162,17 @@ pub fn sleep(ms: u64) void {
     sleep_n_ticks(ms * 1_000_000 / interval_ns);
 }
 
+pub fn get_time_since_boot() u64 {
+    return (ch0_ticks * interval_ns) / 1_000_000;
+}
+
+pub fn get_utime_since_boot() u64 {
+    return (ch0_ticks * interval_ns) / 1_000;
+}
+
 pub fn init() void {
     pit_logger.debug("Initializing PIT", .{});
-    init_channel(.Channel_0, 100);
+    init_channel(.Channel_0, 1000);
     interrupts.set_intr_gate(.Timer, Handler.create(pit_handler, false));
     pic.enable_irq(.Timer);
     pit_logger.info("PIT initialized", .{});

--- a/src/interrupts.zig
+++ b/src/interrupts.zig
@@ -242,7 +242,7 @@ comptime {
 }
 
 pub fn setup_iret_frame(frame: *InterruptFrame) callconv(.C) void {
-    if (!scheduler.initialized)
+    if (!scheduler.is_initialized())
         return;
     scheduler.get_current_task().handle_signal();
     _ = frame;

--- a/src/kernel.zig
+++ b/src/kernel.zig
@@ -2,112 +2,23 @@ const DefaultShell = @import("shell/default/shell.zig");
 const tty = @import("./tty/tty.zig");
 
 const task = @import("task/task.zig");
-const cpu = @import("cpu.zig");
 const wait = @import("task/wait.zig");
-const mapping = @import("memory/mapping.zig");
-const paging = @import("memory/paging.zig");
 const task_set = @import("task/task_set.zig");
 const scheduler = @import("task/scheduler.zig");
 
-var page: *allowzero align(4096) volatile paging.page = undefined;
-var ptr: *volatile u32 = undefined;
 
-fn task1(data: anytype) u8 {
-    const i: u32 = data;
-    const logger = @import("ft").log.scoped(.task1);
-    const current_task = scheduler.get_current_task();
-    if (i == 3) {
-        scheduler.lock();
-        task.init_vm(current_task) catch @panic("asdfasdfasdfasd");
-        if (current_task.vm) |vm| {
-            logger.info("vm: {x:0>8} {}", .{ @intFromPtr(vm), @alignOf(@TypeOf(vm.*)) });
-            page = vm.alloc_pages(1) catch |e| {
-                logger.err("cannot allocate userspace page {s}", .{@errorName(e)});
-                @panic("");
-            };
-            ptr = @ptrCast(page);
-            ptr.* = 42;
-        }
-        scheduler.unlock();
-    }
-    logger.info("{} before value: {}", .{ scheduler.get_current_task().pid, ptr.* });
-    // scheduler.schedule();
-    ptr.* = @intCast(scheduler.get_current_task().pid);
+fn test_tasks() void {
+    task.TaskDescriptor.init_cache() catch @panic("Failed to initialized kernel_task cache");
+    const kernel = task_set.create_task() catch @panic("Failed to create kernel task");
+    _ = kernel;
 
-    // while(true) {}
-    for (0..i) |_| {
-        const new_task = task_set.create_task() catch @panic("c'est  la  panique 4");
-        new_task.clone_vm(scheduler.get_current_task()) catch @panic("c'est  la  panique 4");
-        new_task.spawn(task1, i - 1) catch @panic("c'est  la  panique 4");
-    }
-    // logger.info("coucou\n", .{});
-    logger.info("invoked, {}", .{i});
-    for (0..5) |_| {
-        // logger.info("tic", .{});
-        logger.info("{} value: {} ", .{ scheduler.get_current_task().pid, ptr.* });
-        // ptr.* = @intCast(scheduler.get_current_task().pid);
+    const new_task = task_set.create_task() catch @panic("Failed to create new_task");
+    new_task.spawn(&@import("task/userspace.zig").switch_to_userspace, undefined) catch @panic("Failed to spawn new_task");
 
-        @import("drivers/pit/pit.zig").sleep(1000);
-    }
-    @import("drivers/pit/pit.zig").sleep(1000000);
-    while (true) {
-        // logger.info("tic", .{});
-        logger.info("{} {x:0>8} value: {}", .{
-            scheduler.get_current_task().pid,
-            @intFromPtr(&scheduler.get_current_task().vm.?.directory),
-            ptr.*,
-        });
-        @import("drivers/pit/pit.zig").sleep(1000);
-    }
-    return 43;
-}
-
-fn task2(_: anytype) u8 {
-    const logger = @import("ft").log.scoped(.task2);
-    logger.info("invoked", .{});
-    // scheduler.schedule();
-    for (0..5) |_| {
-        // logger.info("tac", .{});
-        for (0..100_0) |_| asm volatile ("nop");
-        // scheduler.schedule();
-    }
-    return 42;
 }
 
 pub fn main() void {
-    // const logger = @import("ft/ft.zig").log.scoped(.main);
-    task.TaskDescriptor.init_cache() catch @panic("Failed to initialized kernel_task cache");
-    const kernel = task_set.create_task() catch @panic("c'est  la  panique 2");
-    _ = kernel;
-
-    const new_task = task_set.create_task() catch @panic("c'est  la  panique 4");
-    new_task.spawn(&@import("task/userspace.zig").switch_to_userspace, undefined) catch @panic("c'est  la  panique 3");
-
-    // new_task.spawn(task1, 3) catch @panic("c'est  la  panique 3");
-    // const new_task2 = task_set.create_task() catch @panic("c'est  la  panique 4");
-    // new_task2.spawn(&@import("task/userspace.zig").switch_to_userspace, 3) catch @panic("c'est  la  panique 3");
-    // var stat: wait.Status = undefined;
-    // _ = wait.wait(kernel.pid, .CHILD, &stat, .{}) catch @panic("c'est  la  panique 4");
-    //     @import("drivers/pit/pit.zig").sleep(1000);
-
-    // logger.info("coucou\n", .{});
-    // const c2 = task.spawn(task2, null) catch @panic("c'est  la  panique 4");
-    // const c3 = task.spawn(task3, null) catch @panic("c'est  la  panique 5");
-
-    // for (0..1000) |_| {
-    //     scheduler.schedule();
-    // }
-    //
-    // var stat: wait.Status = undefined;
-    // _ = wait.wait(kernel.pid, .CHILD, &stat, .{}) catch @panic("c'est  la  panique 4");
-    // logger.warn("task 1 returned", .{});
-    // _ = wait.wait(kernel.pid, .CHILD, &stat, .{}) catch @panic("c'est  la  panique 5");
-    // logger.warn("task 2 returned", .{});
-    // logger.info("task3 pid: {}", .{c3.pid});
-    // _ = kernel;
-    // _ = c1;
-    // _ = c2;
-    // _ = logger;
+    test_tasks();
 
     var shell = DefaultShell.Shell.init(tty.get_reader(), tty.get_writer(), .{}, .{
         .on_init = DefaultShell.on_init,

--- a/src/kernel.zig
+++ b/src/kernel.zig
@@ -6,14 +6,16 @@ const wait = @import("task/wait.zig");
 const task_set = @import("task/task_set.zig");
 const scheduler = @import("task/scheduler.zig");
 
-
 fn test_tasks() void {
     task.TaskDescriptor.init_cache() catch @panic("Failed to initialized kernel_task cache");
     const kernel = task_set.create_task() catch @panic("Failed to create kernel task");
     _ = kernel;
 
     const new_task = task_set.create_task() catch @panic("Failed to create new_task");
-    new_task.spawn(&@import("task/userspace.zig").switch_to_userspace, undefined) catch @panic("Failed to spawn new_task");
+    new_task.spawn(
+        &@import("task/userspace.zig").switch_to_userspace,
+        undefined,
+    ) catch @panic("Failed to spawn new_task");
 }
 
 pub fn main() void {

--- a/src/kernel.zig
+++ b/src/kernel.zig
@@ -14,7 +14,6 @@ fn test_tasks() void {
 
     const new_task = task_set.create_task() catch @panic("Failed to create new_task");
     new_task.spawn(&@import("task/userspace.zig").switch_to_userspace, undefined) catch @panic("Failed to spawn new_task");
-
 }
 
 pub fn main() void {

--- a/src/misc/philosophers.zig
+++ b/src/misc/philosophers.zig
@@ -4,10 +4,10 @@ const get_time_since_boot = &@import("../drivers/pit/pit.zig").get_time_since_bo
 
 const allocator = @import("../memory.zig").smallAlloc.allocator();
 
-const task = @import("task.zig");
-const wait = @import("wait.zig");
-const scheduler = @import("scheduler.zig");
-const Mutex = @import("semaphore.zig").Mutex;
+const task = @import("../task/task.zig");
+const wait = @import("../task/wait.zig");
+const scheduler = @import("../task/scheduler.zig");
+const Mutex = @import("../task/semaphore.zig").Mutex;
 
 var start_time: u64 = 0;
 var nb_philosophers: u8 = 5;
@@ -60,7 +60,7 @@ pub const Philosopher = struct {
         self.last_meal = get_time_since_boot() - start_time;
         self.check_eos();
         tty.printk("{} {} is eating\n", .{ self.last_meal, self.id });
-        @import("sleep.zig").sleep(time_to_eat);
+        @import("../task/sleep.zig").sleep(time_to_eat);
     }
 
     fn check_eos(self: *Self) void {
@@ -83,7 +83,7 @@ fn philosopher_task(data: usize) u8 {
     const philosopher: *Philosopher = @ptrFromInt(data);
 
     if (philosopher.id % 2 == 1) {
-        @import("sleep.zig").sleep(time_to_eat / 2);
+        @import("../task/sleep.zig").sleep(time_to_eat / 2);
     }
 
     while (true) {
@@ -92,7 +92,7 @@ fn philosopher_task(data: usize) u8 {
         philosopher.drop_forks();
         philosopher.check_eos();
         tty.printk("{} {} is sleeping\n", .{ get_time_since_boot() - start_time, philosopher.id });
-        @import("sleep.zig").sleep(time_to_sleep);
+        @import("../task/sleep.zig").sleep(time_to_sleep);
         philosopher.check_eos();
         tty.printk("{} {} is thinking\n", .{ get_time_since_boot() - start_time, philosopher.id });
     }
@@ -123,7 +123,7 @@ pub fn main(nb: u8, ttd: usize, tte: usize, tts: usize) void {
     }
 
     for (0..nb_philosophers) |i| {
-        const d = @import("task_set.zig").create_task() catch @panic("Failed to create new_task");
+        const d = @import("../task/task_set.zig").create_task() catch @panic("Failed to create new_task");
         _ = d.spawn(philosopher_task, @intFromPtr(&philosophers[i])) catch @panic("Failed to spawn philosopher task");
     }
 

--- a/src/shell/default/builtins.zig
+++ b/src/shell/default/builtins.zig
@@ -347,3 +347,24 @@ pub fn tic(shell: anytype, args: [][]u8) CmdError!void {
         if (n) |*nv| nv.* -= 1;
     }
 }
+
+pub fn philo(_: anytype, args: [][]u8) CmdError!void {
+    // arg 1: nb philosophers
+    // arg 2: time to die
+    // arg 3: time to eat
+    // arg 4: time to sleep
+
+    if (args.len < 5) return CmdError.InvalidNumberOfArguments;
+
+    const nb_philosophers = ft.fmt.parseInt(u8, args[1], 0) catch return CmdError.InvalidParameter;
+    const time_to_die = ft.fmt.parseInt(usize, args[2], 0) catch return CmdError.InvalidParameter;
+    const time_to_eat = ft.fmt.parseInt(usize, args[3], 0) catch return CmdError.InvalidParameter;
+    const time_to_sleep = ft.fmt.parseInt(usize, args[4], 0) catch return CmdError.InvalidParameter;
+
+    @import("../../task/philosophers.zig").main(
+        nb_philosophers,
+        time_to_die,
+        time_to_eat,
+        time_to_sleep,
+    );
+}

--- a/src/shell/default/builtins.zig
+++ b/src/shell/default/builtins.zig
@@ -361,7 +361,7 @@ pub fn philo(_: anytype, args: [][]u8) CmdError!void {
     const time_to_eat = ft.fmt.parseInt(usize, args[3], 0) catch return CmdError.InvalidParameter;
     const time_to_sleep = ft.fmt.parseInt(usize, args[4], 0) catch return CmdError.InvalidParameter;
 
-    @import("../../task/philosophers.zig").main(
+    @import("../../misc/philosophers.zig").main(
         nb_philosophers,
         time_to_die,
         time_to_eat,

--- a/src/shell/default/helpers.zig
+++ b/src/shell/default/helpers.zig
@@ -106,3 +106,11 @@ pub fn spurious() void {
         .usage = null,
     });
 }
+
+pub fn philo() void {
+    print_helper(Help{
+        .name = "philo",
+        .description = "A simple philosopher implemented to test Semaphore / Mutex",
+        .usage = "philo <n> <time_to_die> <time_to_eat> <time_to_sleep>",
+    });
+}

--- a/src/task/philosophers.zig
+++ b/src/task/philosophers.zig
@@ -7,7 +7,7 @@ const allocator = @import("../memory.zig").smallAlloc.allocator();
 const task = @import("task.zig");
 const wait = @import("wait.zig");
 const scheduler = @import("scheduler.zig");
-const Mutex = scheduler.Mutex;
+const Mutex = @import("semaphore.zig").Mutex;
 
 var start_time: u64 = 0;
 var nb_philosophers: u8 = 5;
@@ -60,7 +60,7 @@ pub const Philosopher = struct {
         self.last_meal = get_time_since_boot() - start_time;
         self.check_eos();
         tty.printk("{} {} is eating\n", .{ self.last_meal, self.id });
-        scheduler.sleep(time_to_eat);
+        @import("sleep.zig").sleep(time_to_eat);
     }
 
     fn check_eos(self: *Self) void {
@@ -83,7 +83,7 @@ fn philosopher_task(data: usize) u8 {
     const philosopher: *Philosopher = @ptrFromInt(data);
 
     if (philosopher.id % 2 == 1) {
-        scheduler.sleep(time_to_eat / 2);
+        @import("sleep.zig").sleep(time_to_eat / 2);
     }
 
     while (true) {
@@ -92,7 +92,7 @@ fn philosopher_task(data: usize) u8 {
         philosopher.drop_forks();
         philosopher.check_eos();
         tty.printk("{} {} is sleeping\n", .{ get_time_since_boot() - start_time, philosopher.id });
-        scheduler.sleep(time_to_sleep);
+        @import("sleep.zig").sleep(time_to_sleep);
         philosopher.check_eos();
         tty.printk("{} {} is thinking\n", .{ get_time_since_boot() - start_time, philosopher.id });
     }

--- a/src/task/philosophers.zig
+++ b/src/task/philosophers.zig
@@ -1,0 +1,156 @@
+const ft = @import("ft");
+const tty = @import("../tty/tty.zig");
+const get_time_since_boot = &@import("../drivers/pit/pit.zig").get_time_since_boot;
+
+const allocator = @import("../memory.zig").smallAlloc.allocator();
+
+const task = @import("task.zig");
+const wait = @import("wait.zig");
+const scheduler = @import("scheduler.zig");
+const Mutex = scheduler.Mutex;
+
+var start_time: u64 = 0;
+var nb_philosophers: u8 = 5;
+var time_to_die: usize = 410;
+var time_to_eat: usize = 200;
+var time_to_sleep: usize = 200;
+var end_of_simulation: bool = false;
+var eos_mutex = Mutex{};
+
+pub const Philosopher = struct {
+    const Self = @This();
+
+    id: u8,
+    left: *Mutex,
+    right: *Mutex,
+    forks_flag: struct { left: bool = false, right: bool = false } = .{},
+
+    // num_of_eats: u32 = 0,
+
+    last_meal: u64 = 0,
+    last_sleep: u64 = 0,
+
+    pub fn init(id: u8, left: *Mutex, right: *Mutex) Self {
+        return Self{
+            .id = id,
+            .left = left,
+            .right = right,
+        };
+    }
+
+    pub fn take_forks(self: *Self) void {
+        self.left.acquire();
+        self.forks_flag.left = true;
+        self.check_eos();
+        tty.printk("{} {} has taken a fork\n", .{ get_time_since_boot() - start_time, self.id });
+        self.right.acquire();
+        self.forks_flag.right = true;
+        self.check_eos();
+        tty.printk("{} {} has taken a fork\n", .{ get_time_since_boot() - start_time, self.id });
+    }
+
+    pub fn drop_forks(self: *Self) void {
+        self.left.release();
+        self.forks_flag.left = false;
+        self.right.release();
+        self.forks_flag.right = false;
+    }
+
+    pub fn eat(self: *Self) void {
+        self.last_meal = get_time_since_boot() - start_time;
+        self.check_eos();
+        tty.printk("{} {} is eating\n", .{ self.last_meal, self.id });
+        scheduler.sleep(time_to_eat);
+    }
+
+    fn check_eos(self: *Self) void {
+        eos_mutex.acquire();
+        if (end_of_simulation) {
+            eos_mutex.release();
+            if (self.forks_flag.left) {
+                self.left.release();
+            }
+            if (self.forks_flag.right) {
+                self.right.release();
+            }
+            task.exit(0);
+        }
+        eos_mutex.release();
+    }
+};
+
+fn philosopher_task(data: usize) u8 {
+    const philosopher: *Philosopher = @ptrFromInt(data);
+
+    if (philosopher.id % 2 == 1) {
+        scheduler.sleep(time_to_eat / 2);
+    }
+
+    while (true) {
+        philosopher.take_forks();
+        philosopher.eat();
+        philosopher.drop_forks();
+        philosopher.check_eos();
+        tty.printk("{} {} is sleeping\n", .{ get_time_since_boot() - start_time, philosopher.id });
+        scheduler.sleep(time_to_sleep);
+        philosopher.check_eos();
+        tty.printk("{} {} is thinking\n", .{ get_time_since_boot() - start_time, philosopher.id });
+    }
+    return 0;
+}
+
+pub fn main(nb: u8, ttd: usize, tte: usize, tts: usize) void {
+    tty.printk("Starting philosophers\n", .{});
+
+    nb_philosophers = nb;
+    time_to_die = ttd;
+    time_to_eat = tte;
+    time_to_sleep = tts;
+    end_of_simulation = false;
+
+    start_time = get_time_since_boot();
+
+    var mutexes: []Mutex = allocator.alloc(Mutex, nb_philosophers) catch @panic("Failed to allocate mutexes");
+    var philosophers: []Philosopher = allocator.alloc(
+        Philosopher,
+        nb_philosophers,
+    ) catch @panic("Failed to allocate philosophers");
+
+    for (0..nb_philosophers) |i| {
+        tty.printk("initializing philosopher {}\n", .{i});
+        mutexes[i] = Mutex{};
+        philosophers[i] = Philosopher.init(@intCast(i), &mutexes[i], &mutexes[(i + 1) % nb_philosophers]);
+    }
+
+    for (0..nb_philosophers) |i| {
+        const d = @import("task_set.zig").create_task() catch @panic("Failed to create new_task");
+        _ = d.spawn(philosopher_task, @intFromPtr(&philosophers[i])) catch @panic("Failed to spawn philosopher task");
+    }
+
+    const status: bool = b: while (true) {
+        for (philosophers) |philo| {
+            eos_mutex.acquire();
+            if (get_time_since_boot() - start_time - philo.last_meal > time_to_die) {
+                tty.printk("{} {} died\n", .{ get_time_since_boot() - start_time, philo.id });
+                end_of_simulation = true;
+                eos_mutex.release();
+                break :b true;
+            }
+            eos_mutex.release();
+        }
+        _ = scheduler.schedule();
+    };
+
+    const current_pid = task.getpid();
+    for (philosophers) |philo| {
+        var stat: wait.Status = undefined;
+        _ = wait.wait(
+            current_pid,
+            .CHILD,
+            &stat,
+            .{},
+        ) catch ft.log.warn("Failed to wait for philosopher {}", .{philo.id});
+    }
+
+    tty.printk("End of simulation {}\n", .{status});
+}

--- a/src/task/ready_queue.zig
+++ b/src/task/ready_queue.zig
@@ -19,14 +19,13 @@ pub fn append(new_node: *TaskDescriptor) void {
     scheduler.lock();
     defer scheduler.unlock();
 
-    if (new_node.rq_node.data) |_| ft.log.err(
-        "Trying to append a task that is already in the ReadyQueue (rq: {*}, pid: {}, rq_node.data: {*})",
-        .{ &ready_queue, new_node.pid, new_node.rq_node.data },
-    );
+    defer {
+        new_node.rq_node.data = @ptrCast(&ready_queue);
+        new_node.state = .Ready;
+    }
 
-    new_node.rq_node.data = @ptrCast(&ready_queue);
+    if (new_node.rq_node.data) |_| return;
     ready_queue.append(&new_node.rq_node);
-    new_node.state = .Ready;
 }
 
 pub fn prepend(new_node: *TaskDescriptor) void {

--- a/src/task/ready_queue.zig
+++ b/src/task/ready_queue.zig
@@ -1,0 +1,91 @@
+const ft = @import("ft");
+const scheduler = @import("scheduler.zig");
+const TaskDescriptor = @import("task.zig").TaskDescriptor;
+
+const Self = @This();
+
+// Queue.Node.Data is a pointer to the ready_queue (here defined as ?*usize to avoid circular dependencies).
+// It is used to check efficiently if a task is already in the ready_queue when adding it, or even to avoid
+// removing it twice (which would break the DoublyLinkedList len)
+// If we wanna save some memor, we could set the data type to void (@SizeOf(void) == 0), but then we would have
+// to do some linear search to perform our checks.
+const Queue = ft.DoublyLinkedList(?*usize);
+
+pub const Node = Queue.Node;
+
+pub var ready_queue = Queue{};
+
+pub fn append(new_node: *TaskDescriptor) void {
+    scheduler.lock();
+    defer scheduler.unlock();
+
+    if (new_node.rq_node.data) |_| ft.log.err(
+        "Trying to append a task that is already in the ReadyQueue (rq: {*}, pid: {}, rq_node.data: {*})",
+        .{ &ready_queue, new_node.pid, new_node.rq_node.data },
+    );
+
+    new_node.rq_node.data = @ptrCast(&ready_queue);
+    ready_queue.append(&new_node.rq_node);
+    new_node.state = .Ready;
+}
+
+pub fn prepend(new_node: *TaskDescriptor) void {
+    scheduler.lock();
+    defer scheduler.unlock();
+
+    if (new_node.rq_node.data) |_| ft.log.err(
+        "Trying to prepend a task that is already in the ReadyQueue (rq: {*}, pid: {}, rq_node.data: {*})",
+        .{ &ready_queue, new_node.pid, new_node.rq_node.data },
+    );
+
+    new_node.rq_node.data = @ptrCast(&ready_queue);
+    ready_queue.prepend(&new_node.rq_node);
+    new_node.state = .Ready;
+}
+
+pub fn remove(t: *TaskDescriptor) void {
+    scheduler.lock();
+    defer scheduler.unlock();
+
+    if (t.rq_node.data == null) return;
+
+    ready_queue.remove(&t.rq_node);
+    t.rq_node.data = null;
+
+    // Should we set the task to a different state here ???
+    // Not sure, as this method is called during an exit, right after setting it to .Zombie state.
+    // TODO: Maybe we should discuss it together.
+}
+
+pub fn popFirst() ?*Queue.Node {
+    scheduler.lock();
+    defer scheduler.unlock();
+
+    const node = ready_queue.popFirst();
+    if (node) |n| n.data = null;
+    return node;
+}
+
+pub fn pop() ?*Queue.Node {
+    scheduler.lock();
+    defer scheduler.unlock();
+
+    const node = ready_queue.pop();
+    if (node) |n| n.data = null;
+    return node;
+}
+
+pub fn debug_ready_queue(message: []const u8) void {
+    ft.log.info("ReadyQueue: {}", .{message});
+    var node = ready_queue.head;
+    while (node) {
+        const td = scheduler.test_get_td(node, "rq_node");
+        ft.log.info("pid: {}, state: {}", .{ td.pid, td.state });
+        node = node.next;
+    }
+}
+
+pub fn get_task_descriptor(node: *Queue.Node, comptime fieldname: []const u8) *TaskDescriptor {
+    const offset = @offsetOf(TaskDescriptor, fieldname);
+    return @ptrFromInt(@as(usize, @intFromPtr(node)) - offset);
+}

--- a/src/task/ready_queue.zig
+++ b/src/task/ready_queue.zig
@@ -2,12 +2,12 @@ const ft = @import("ft");
 const scheduler = @import("scheduler.zig");
 const TaskDescriptor = @import("task.zig").TaskDescriptor;
 
-// Queue.Node.Data is a pointer to the ready_queue (here defined as ?*usize to avoid circular dependencies).
+// Queue.Node.Data is a bool.
 // It is used to check efficiently if a task is already in the ready_queue when adding it, or even to avoid
 // removing it twice (which would break the DoublyLinkedList len)
-// If we wanna save some memor, we could set the data type to void (@SizeOf(void) == 0), but then we would have
+// If we wanna save some memory, we could set the data type to void (as @SizeOf(void) == 0), but then we would have
 // to do some linear search to perform our checks.
-const Queue = ft.DoublyLinkedList(?*usize);
+const Queue = ft.DoublyLinkedList(bool);
 
 pub const Node = Queue.Node;
 
@@ -17,10 +17,10 @@ pub fn push(new_node: *TaskDescriptor) void {
     scheduler.lock();
     defer scheduler.unlock();
 
-    if (new_node.rq_node.data == null)
+    if (new_node.rq_node.data == false)
         ready_queue.append(&new_node.rq_node);
 
-    new_node.rq_node.data = @ptrCast(&ready_queue);
+    new_node.rq_node.data = true;
     new_node.state = .Ready;
 }
 
@@ -29,7 +29,7 @@ pub fn pop() ?*Queue.Node {
     defer scheduler.unlock();
 
     const node = ready_queue.popFirst();
-    if (node) |n| n.data = null;
+    if (node) |n| n.data = false;
     return node;
 }
 
@@ -37,10 +37,10 @@ pub fn remove(t: *TaskDescriptor) void {
     scheduler.lock();
     defer scheduler.unlock();
 
-    if (t.rq_node.data == null) return;
+    if (t.rq_node.data == false) return;
 
     ready_queue.remove(&t.rq_node);
-    t.rq_node.data = null;
+    t.rq_node.data = false;
 
     // Should we set the task to a different state here ???
     // Not sure, as this method is called during an exit, right after setting it to .Zombie state.

--- a/src/task/ready_queue.zig
+++ b/src/task/ready_queue.zig
@@ -2,8 +2,6 @@ const ft = @import("ft");
 const scheduler = @import("scheduler.zig");
 const TaskDescriptor = @import("task.zig").TaskDescriptor;
 
-const Self = @This();
-
 // Queue.Node.Data is a pointer to the ready_queue (here defined as ?*usize to avoid circular dependencies).
 // It is used to check efficiently if a task is already in the ready_queue when adding it, or even to avoid
 // removing it twice (which would break the DoublyLinkedList len)
@@ -15,31 +13,24 @@ pub const Node = Queue.Node;
 
 pub var ready_queue = Queue{};
 
-pub fn append(new_node: *TaskDescriptor) void {
+pub fn push(new_node: *TaskDescriptor) void {
     scheduler.lock();
     defer scheduler.unlock();
 
-    defer {
-        new_node.rq_node.data = @ptrCast(&ready_queue);
-        new_node.state = .Ready;
-    }
-
-    if (new_node.rq_node.data) |_| return;
-    ready_queue.append(&new_node.rq_node);
-}
-
-pub fn prepend(new_node: *TaskDescriptor) void {
-    scheduler.lock();
-    defer scheduler.unlock();
-
-    if (new_node.rq_node.data) |_| ft.log.err(
-        "Trying to prepend a task that is already in the ReadyQueue (rq: {*}, pid: {}, rq_node.data: {*})",
-        .{ &ready_queue, new_node.pid, new_node.rq_node.data },
-    );
+    if (new_node.rq_node.data == null)
+        ready_queue.append(&new_node.rq_node);
 
     new_node.rq_node.data = @ptrCast(&ready_queue);
-    ready_queue.prepend(&new_node.rq_node);
     new_node.state = .Ready;
+}
+
+pub fn pop() ?*Queue.Node {
+    scheduler.lock();
+    defer scheduler.unlock();
+
+    const node = ready_queue.popFirst();
+    if (node) |n| n.data = null;
+    return node;
 }
 
 pub fn remove(t: *TaskDescriptor) void {
@@ -54,37 +45,4 @@ pub fn remove(t: *TaskDescriptor) void {
     // Should we set the task to a different state here ???
     // Not sure, as this method is called during an exit, right after setting it to .Zombie state.
     // TODO: Maybe we should discuss it together.
-}
-
-pub fn popFirst() ?*Queue.Node {
-    scheduler.lock();
-    defer scheduler.unlock();
-
-    const node = ready_queue.popFirst();
-    if (node) |n| n.data = null;
-    return node;
-}
-
-pub fn pop() ?*Queue.Node {
-    scheduler.lock();
-    defer scheduler.unlock();
-
-    const node = ready_queue.pop();
-    if (node) |n| n.data = null;
-    return node;
-}
-
-pub fn debug_ready_queue(message: []const u8) void {
-    ft.log.info("ReadyQueue: {}", .{message});
-    var node = ready_queue.head;
-    while (node) {
-        const td = scheduler.test_get_td(node, "rq_node");
-        ft.log.info("pid: {}, state: {}", .{ td.pid, td.state });
-        node = node.next;
-    }
-}
-
-pub fn get_task_descriptor(node: *Queue.Node, comptime fieldname: []const u8) *TaskDescriptor {
-    const offset = @offsetOf(TaskDescriptor, fieldname);
-    return @ptrFromInt(@as(usize, @intFromPtr(node)) - offset);
 }

--- a/src/task/scheduler.zig
+++ b/src/task/scheduler.zig
@@ -26,11 +26,94 @@ pub fn init(new_task: *task.TaskDescriptor) void {
     current_task = new_task;
 }
 
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// TEST WAIT QUEUES / SLEEPING
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+const pit = @import("../drivers/pit/pit.zig");
+fn sleep_callback(t: *task.TaskDescriptor) void {
+    t.state = .Sleeping;
+    schedule();
+}
+fn wakeup_callback(t: *task.TaskDescriptor) bool {
+    return pit.get_utime_since_boot() >= t.sleep_timeout;
+}
+
+var sleep_queue = @import("wait_queue.zig").WaitQueue(sleep_callback, wakeup_callback){};
+
+// wait queue but for semarphores
+fn semaphore_block_callback(t: *task.TaskDescriptor) void {
+    t.state = .Blocked;
+    schedule();
+}
+fn semaphore_unblock_callback(t: *task.TaskDescriptor) bool {
+    return t.state != .Blocked;
+}
+
+const scheduler = @This();
+
+pub fn Semaphore(max_count: u32) type {
+    return struct {
+        const Self = @This();
+
+        count: u32 = 0,
+        max_count: u32 = max_count,
+        queue: @import("wait_queue.zig").WaitQueue(semaphore_block_callback, semaphore_unblock_callback) = .{},
+
+        pub inline fn acquire(self: *Self) void {
+            scheduler.lock();
+            defer scheduler.unlock();
+
+            if (self.count < self.max_count) {
+                self.count += 1;
+            } else {
+                self.queue.block(current_task);
+                scheduler.schedule();
+            }
+        }
+
+        pub inline fn release(self: *Self) void {
+            scheduler.lock();
+            defer scheduler.unlock();
+
+            if (self.queue.queue.first) |first| {
+                first.data.state = .Ready;
+                self.queue.try_unblock();
+            } else {
+                self.count -= 1;
+            }
+        }
+    };
+}
+
+pub const Mutex = Semaphore(1);
+
+pub fn usleep(micro: u64) void {
+    @This().lock();
+    defer @This().unlock();
+
+    const t = current_task;
+    t.sleep_timeout = pit.get_utime_since_boot() + micro;
+
+    // if (t.sleep_timeout <= pit.get_utime_since_boot()) return;
+
+    sleep_queue.block(t);
+    schedule();
+}
+
+pub fn sleep(millis: u64) void {
+    @This().lock();
+    defer @This().unlock();
+
+    usleep(millis * 1000);
+}
+
 pub fn schedule() void {
     if (!initialized) return;
 
     @This().lock();
     defer @This().unlock();
+
+    sleep_queue.try_unblock();
 
     if (ready_queue.popFirst()) |node| {
         const prev = current_task;

--- a/src/task/scheduler.zig
+++ b/src/task/scheduler.zig
@@ -39,9 +39,9 @@ pub fn schedule() void {
 
     @import("sleep.zig").try_unblock_sleeping_task();
 
-    if (ready_queue.popFirst()) |node| {
+    if (ready_queue.pop()) |node| {
         const prev = current_task;
-        current_task = ready_queue.get_task_descriptor(node, "rq_node");
+        current_task = @alignCast(@fieldParentPtr("rq_node", node));
         task.switch_to_task(prev, current_task);
     }
 }

--- a/src/task/semaphore.zig
+++ b/src/task/semaphore.zig
@@ -41,6 +41,7 @@ pub fn Semaphore(max_count: u32) type {
                 first.data.state = .Ready;
                 self.queue.try_unblock();
             } else {
+                if (self.count == 0) @panic("Trying to release a unacquired semaphore");
                 self.count -= 1;
             }
         }

--- a/src/task/semaphore.zig
+++ b/src/task/semaphore.zig
@@ -1,0 +1,50 @@
+const task = @import("task.zig");
+const scheduler = @import("scheduler.zig");
+
+fn semaphore_block_callback(t: *task.TaskDescriptor) void {
+    t.state = .Blocked;
+    scheduler.schedule();
+}
+
+fn semaphore_predicate(t: *task.TaskDescriptor) bool {
+    return t.state == .Ready;
+}
+
+pub fn Semaphore(max_count: u32) type {
+    return struct {
+        const Self = @This();
+
+        count: u32 = 0,
+        max_count: u32 = max_count,
+        queue: @import("wait_queue.zig").WaitQueue(.{
+            .block_callback = semaphore_block_callback,
+            .predicate = semaphore_predicate,
+        }) = .{},
+
+        pub inline fn acquire(self: *Self) void {
+            scheduler.lock();
+            defer scheduler.unlock();
+
+            if (self.count < self.max_count) {
+                self.count += 1;
+            } else {
+                self.queue.block(scheduler.get_current_task());
+                scheduler.schedule();
+            }
+        }
+
+        pub inline fn release(self: *Self) void {
+            scheduler.lock();
+            defer scheduler.unlock();
+
+            if (self.queue.queue.first) |first| {
+                first.data.state = .Ready;
+                self.queue.try_unblock();
+            } else {
+                self.count -= 1;
+            }
+        }
+    };
+}
+
+pub const Mutex = Semaphore(1);

--- a/src/task/signal.zig
+++ b/src/task/signal.zig
@@ -127,7 +127,7 @@ pub const SignalQueue = struct {
     fn is_ignored(self: Self) bool {
         return !self.action.sa_flags.SA_SIGINFO and
             (self.action.sa_handler == SIG_IGN or
-            (self.action.sa_handler == SIG_DFL and self.default_handler == .Ignore));
+                (self.action.sa_handler == SIG_DFL and self.default_handler == .Ignore));
     }
 
     pub fn queue_signal(self: *Self, signal: siginfo_t) void {

--- a/src/task/sleep.zig
+++ b/src/task/sleep.zig
@@ -27,8 +27,6 @@ pub fn usleep(micro: u64) void {
     const t = scheduler.get_current_task();
     t.sleep_timeout = pit.get_utime_since_boot() + micro;
 
-    // if (t.sleep_timeout <= pit.get_utime_since_boot()) return;
-
     sleep_queue.block(t);
     scheduler.schedule();
 }

--- a/src/task/sleep.zig
+++ b/src/task/sleep.zig
@@ -1,0 +1,41 @@
+const task = @import("task.zig");
+const pit = @import("../drivers/pit/pit.zig");
+const scheduler = @import("scheduler.zig");
+
+fn sleep_callback(t: *task.TaskDescriptor) void {
+    t.state = .Sleeping;
+    scheduler.schedule();
+}
+
+fn sleep_predicate(t: *task.TaskDescriptor) bool {
+    return t.state == .Sleeping and pit.get_utime_since_boot() >= t.sleep_timeout;
+}
+
+var sleep_queue = @import("wait_queue.zig").WaitQueue(.{
+    .block_callback = sleep_callback,
+    .predicate = sleep_predicate,
+}){};
+
+pub fn try_unblock_sleeping_task() void {
+    sleep_queue.try_unblock();
+}
+
+pub fn usleep(micro: u64) void {
+    scheduler.lock();
+    defer scheduler.unlock();
+
+    const t = scheduler.get_current_task();
+    t.sleep_timeout = pit.get_utime_since_boot() + micro;
+
+    // if (t.sleep_timeout <= pit.get_utime_since_boot()) return;
+
+    sleep_queue.block(t);
+    scheduler.schedule();
+}
+
+pub fn sleep(millis: u64) void {
+    scheduler.lock();
+    defer scheduler.unlock();
+
+    usleep(millis * 1000);
+}

--- a/src/task/task.zig
+++ b/src/task/task.zig
@@ -42,7 +42,7 @@ pub const TaskDescriptor = struct {
     ucontext: ucontext.ucontext_t = .{},
 
     // scheduling
-    rq_node: ready_queue.Node = .{ .data = null },
+    rq_node: ready_queue.Node = .{ .data = false },
     sleep_timeout: u64 = 0,
 
     pub const State = enum(u8) {

--- a/src/task/task.zig
+++ b/src/task/task.zig
@@ -319,8 +319,7 @@ pub fn switch_to_task(prev: *TaskDescriptor, next: *TaskDescriptor) void {
     defer scheduler.unlock();
 
     if (prev.state == .Running) {
-        prev.state = .Ready;
-        ready_queue.append(prev);
+        ready_queue.push(prev);
     }
     next.state = .Running;
 

--- a/src/task/task.zig
+++ b/src/task/task.zig
@@ -43,11 +43,14 @@ pub const TaskDescriptor = struct {
 
     // scheduling
     rq_node: ready_queue.Node = .{ .data = null },
+    sleep_timeout: u64 = 0,
 
     pub const State = enum(u8) {
         Running,
+        Blocked,
         Ready,
         Stopped,
+        Sleeping,
         Zombie,
     };
     pub const Pid = i32;

--- a/src/task/task_set.zig
+++ b/src/task/task_set.zig
@@ -20,7 +20,7 @@ pub fn create_task() !*TaskDescriptor {
         new_task.* = .{ .pid = pid, .pgid = pid, .parent = null, .state = .Running };
         scheduler.init(new_task);
     } else {
-        new_task.* = .{ .pid = pid, .pgid = parent.pgid, .parent = parent, .state = .Running };
+        new_task.* = .{ .pid = pid, .pgid = parent.pgid, .parent = parent, .state = .Ready };
         new_task.next_sibling = parent.childs;
         parent.childs = new_task;
     }
@@ -54,7 +54,7 @@ pub fn destroy_task(pid: TaskDescriptor.Pid) !void {
     if (pid < 0) return error.NoSuchTask;
     const index: u32 = @intCast(pid);
     const descriptor = list[index] orelse return error.NoSuchTask; // todo error
-    scheduler.remove_task(descriptor);
+    @import("ready_queue.zig").remove(descriptor);
     descriptor.deinit();
     list[index] = null;
     count -= 1;

--- a/src/task/wait_queue.zig
+++ b/src/task/wait_queue.zig
@@ -1,0 +1,67 @@
+const TaskDescriptor = @import("task.zig").TaskDescriptor;
+const scheduler = @import("scheduler.zig");
+const ready_queue = @import("ready_queue.zig");
+
+const Queue = @import("ft").DoublyLinkedList(*TaskDescriptor);
+const Node = Queue.Node;
+
+const allocator = @import("../memory.zig").smallAlloc.allocator();
+
+pub fn WaitQueue(block_callback: fn (*TaskDescriptor) void, unblock_callback: fn (*TaskDescriptor) bool) type {
+    return struct {
+        const Self = @This();
+
+        queue: Queue = .{},
+
+        pub fn block(self: *Self, task: *TaskDescriptor) void {
+            scheduler.lock();
+            defer scheduler.unlock();
+
+            const node: *Node = allocator.create(Node) catch @panic("wq.block");
+            node.data = task;
+            self.queue.append(node);
+            block_callback(task);
+        }
+
+        pub fn try_unblock(self: *Self) void {
+            scheduler.lock();
+            defer scheduler.unlock();
+
+            var node = self.queue.first;
+            while (node) |n| {
+                const task = n.data;
+                const next = n.next;
+                if (unblock_callback(task)) {
+                    ready_queue.append(task);
+                    self.queue.remove(n);
+                    allocator.destroy(n);
+                }
+                node = next;
+            }
+        }
+
+        // // Remove and return the first node in the list.
+        // pub fn popFirst(self: *Self) ?*TaskDescriptor {
+        //     scheduler.lock();
+        //     defer scheduler.unlock();
+
+        //     return self.queue.popFirst();
+        // }
+
+        // // Insert a new node at the beginning of the list.
+        // pub fn prepend(self: *Self, task: *TaskDescriptor) void {
+        //     scheduler.lock();
+        //     defer scheduler.unlock();
+
+        //     self.queue.prepend(task);
+        // }
+
+        // // Remove a node from the list.
+        // pub fn remove(self: *Self, node: *TaskDescriptor) void {
+        //     scheduler.lock();
+        //     defer scheduler.unlock();
+
+        //     self.queue.remove(node);
+        // }
+    };
+}

--- a/src/task/wait_queue.zig
+++ b/src/task/wait_queue.zig
@@ -43,7 +43,7 @@ pub fn WaitQueue(arg: WaitQueueArg) type {
                 const task = n.data;
                 const next = n.next;
                 if (arg.predicate(task)) {
-                    ready_queue.append(task);
+                    ready_queue.push(task);
                     self.queue.remove(n);
                     allocator.destroy(n);
                     if (arg.unblock_callback) |callback| callback(task);
@@ -51,29 +51,5 @@ pub fn WaitQueue(arg: WaitQueueArg) type {
                 node = next;
             }
         }
-
-        // // Remove and return the first node in the list.
-        // pub fn popFirst(self: *Self) ?*TaskDescriptor {
-        //     scheduler.lock();
-        //     defer scheduler.unlock();
-
-        //     return self.queue.popFirst();
-        // }
-
-        // // Insert a new node at the beginning of the list.
-        // pub fn prepend(self: *Self, task: *TaskDescriptor) void {
-        //     scheduler.lock();
-        //     defer scheduler.unlock();
-
-        //     self.queue.prepend(task);
-        // }
-
-        // // Remove a node from the list.
-        // pub fn remove(self: *Self, node: *TaskDescriptor) void {
-        //     scheduler.lock();
-        //     defer scheduler.unlock();
-
-        //     self.queue.remove(node);
-        // }
     };
 }

--- a/src/tty/tty.zig
+++ b/src/tty/tty.zig
@@ -613,11 +613,12 @@ var ttyBufferWriter = init: {
     break :init array;
 };
 
+var write_lock = @import("../task/scheduler.zig").Mutex{};
+
 /// print a formatted string to the current terminal using WriterBuffers
 pub inline fn printk(comptime fmt: []const u8, args: anytype) void {
-    // TODO: replace the scheduler lock with a semaphore when implemented
-    @import("../task/scheduler.zig").lock();
-    defer @import("../task/scheduler.zig").unlock();
+    write_lock.acquire();
+    defer write_lock.release();
 
     ttyBufferWriter[current_tty].print(fmt, args) catch {};
     ttyBufferWriter[current_tty].flush() catch {};

--- a/src/tty/tty.zig
+++ b/src/tty/tty.zig
@@ -613,7 +613,7 @@ var ttyBufferWriter = init: {
     break :init array;
 };
 
-var write_lock = @import("../task/scheduler.zig").Mutex{};
+var write_lock = @import("../task/semaphore.zig").Mutex{};
 
 /// print a formatted string to the current terminal using WriterBuffers
 pub inline fn printk(comptime fmt: []const u8, args: anytype) void {


### PR DESCRIPTION
## ADD run_queue prototype (feaa90a753ade96cf63fb5a186d421d9997937fe)

This commit introduces a run_queue prototype which is basically a ft.DoublyLinkedList wrapper.

## ADD wait_queue prototype (1093cbf8410fd302e3cb235dbcb47dc94278f7eb)

This commit introduces a wait_queue prototype.
A sleep queue prototype is implemented using this wait_queue.
A Semaphore (and Mutex) prototype is also implemented using the wait_queue prototype.

## UPDATE gitignore (377af14b671b57de13883c1b606cb7cc9eb4ffb6) 

Add src/syscall_table.zig to gitignore as it's an auto-generated file.

## REWORK tty printk (0b654dd9f70dad2c1ca4aebc38696f136cee1783) 

Replace scheduler lock/unlock from printk for a simple mutex.

## ADD philosopher (2d26bcacf3ba5c3d4c2ee225a7013122fafe0d9f) 

This commit add a philosopher implementation as a POC for wait queues and semaphores/mutexes.

## REWORK wait_queue and semaphore (b5b07efb01fd544576d27029423b45edb22b2ba6) 

Add a wait_queue arg struct declaring:
- block_callback: the method called when a task is added to the wait queue
- predicate: the method called to determine if a task should be unblocked
- unblock_callback: the method called when a task is unblocked

Separate sleep and semaphore from scheduler.zig and put it in 2 separate files:
- src/task/sleep.zig
- src/task/semaphore.zig

## CHORE move philosophers.zig (3832788b2adfe4564fce7053e5c099c02955fe33)

Move philosophers.zig from src/task to src/misc

## Apply suggestions from code review (c2b8fc1b9f7829eb46d5c9f251e0dcf91a47c1a2)

Co-authored-by: Joachim Giron <59100853+jgiron42@users.noreply.github.com>

## REWORK ready_queue (584bf208458ecabf6905e555a9a64d03ebe1c05f)

Declare the ready_queue.Node.data as a bool instead of a ?*usize.

## UPDATE add check on semaphore release (543a83126b0b4402baaeb777b70049ebedf4a4a7)

Add a check to avoid releasing an un-acquired semaphore.