### PR TITLE
ADD getuid syscall:

### DIFF
--- a/src/syscall/getuid.zig
+++ b/src/syscall/getuid.zig
@@ -1,0 +1,6 @@
+pub const Id = 15;
+const scheduler = @import("../task/scheduler.zig");
+
+pub fn do() !u32 {
+    return scheduler.get_current_task().owner;
+}

--- a/src/task/task.zig
+++ b/src/task/task.zig
@@ -22,6 +22,8 @@ pub const TaskDescriptor = struct {
     pid: Pid,
     pgid: Pid,
 
+    owner: u32 = 0,
+
     state: State,
 
     parent: ?*TaskDescriptor,


### PR DESCRIPTION
This commit introduces the getuid syscall.
Up to now, the owner id in task is a simple placeholder to prepare the future implementation of system users