### PR TITLE
CHORE add some mutexes to protect critical parts:

### DIFF
--- a/src/memory/object_allocators/slab/slab.zig
+++ b/src/memory/object_allocators/slab/slab.zig
@@ -54,8 +54,8 @@ pub const Slab = struct {
 
         const index = next * (self.header.cache.size_obj / @sizeOf(usize));
         switch (self.get_state()) {
-            .Empty => self.header.cache.move_slab(self, .Partial),
-            .Partial => if (self.data[index] == null) self.header.cache.move_slab(self, .Full),
+            .Empty => self.header.cache.unsafe_move_slab(self, .Partial),
+            .Partial => if (self.data[index] == null) self.header.cache.unsafe_move_slab(self, .Full),
             .Full => unreachable,
         }
         self.header.next_free = self.data[index];
@@ -84,8 +84,8 @@ pub const Slab = struct {
         self.bitmap.set(index, Bit.Free) catch unreachable;
         switch (self.get_state()) {
             .Empty => unreachable,
-            .Partial => if (self.header.in_use == 1) self.header.cache.move_slab(self, .Empty),
-            .Full => self.header.cache.move_slab(self, .Partial),
+            .Partial => if (self.header.in_use == 1) self.header.cache.unsafe_move_slab(self, .Empty),
+            .Full => self.header.cache.unsafe_move_slab(self, .Partial),
         }
         self.header.in_use -= 1;
         self.data[index * (self.header.cache.size_obj / @sizeOf(usize))] = self.header.next_free;

--- a/src/task/semaphore.zig
+++ b/src/task/semaphore.zig
@@ -39,7 +39,8 @@ pub fn Semaphore(max_count: u32) type {
             defer scheduler.unlock();
 
             if (self.queue.queue.first) |first| {
-                first.data.state = .Ready;
+                const _t: *task.TaskDescriptor = @alignCast(@fieldParentPtr("wq_node", first));
+                _t.state = .Ready;
                 self.queue.try_unblock();
             } else {
                 if (self.count == 0) @panic("Trying to release a unacquired semaphore");

--- a/src/task/semaphore.zig
+++ b/src/task/semaphore.zig
@@ -28,6 +28,7 @@ pub fn Semaphore(max_count: u32) type {
             if (self.count < self.max_count) {
                 self.count += 1;
             } else {
+                if (!scheduler.is_initialized()) @panic("Max count reached for a semaphore during early boot stage");
                 self.queue.block(scheduler.get_current_task());
                 scheduler.schedule();
             }

--- a/src/task/task.zig
+++ b/src/task/task.zig
@@ -11,6 +11,7 @@ const ucontext = @import("ucontext.zig");
 const Cache = @import("../memory/object_allocators/slab/cache.zig").Cache;
 const scheduler = @import("scheduler.zig");
 const ready_queue = @import("ready_queue.zig");
+const wait_queue = @import("wait_queue.zig");
 const status_informations = @import("status_informations.zig");
 const StatusStack = @import("status_stack.zig").StatusStack;
 const logger = ft.log.scoped(.task);
@@ -18,7 +19,7 @@ const Errno = @import("../errno.zig").Errno;
 
 pub const TaskDescriptor = struct {
     // todo: define the appropriate size for a kernelspace stack or get this value from config
-    stack: [16 * 1024]u8 align(4096) = undefined,
+    stack: [64 * 1024]u8 align(4096) = undefined,
     pid: Pid,
     pgid: Pid,
 
@@ -45,6 +46,8 @@ pub const TaskDescriptor = struct {
 
     // scheduling
     rq_node: ready_queue.Node = .{ .data = false },
+    wq_node: wait_queue.Node = .{ .data = null },
+
     sleep_timeout: u64 = 0,
 
     pub const State = enum(u8) {

--- a/src/tty/buffer_writer.zig
+++ b/src/tty/buffer_writer.zig
@@ -1,4 +1,5 @@
 const ft = @import("ft");
+const Mutex = @import("../task/semaphore.zig").Mutex;
 
 /// this class wrap a Writer and provide bufferization
 pub fn BufferWriter(
@@ -13,34 +14,48 @@ pub fn BufferWriter(
         context: Context,
         buffer: [size]u8 = undefined,
         index: usize = 0,
+        lock: Mutex = Mutex{},
 
         const Self = @This();
 
         pub fn print(self: *Self, comptime format: []const u8, args: anytype) Error!void {
+            self.lock.acquire();
+            defer self.lock.release();
+
             return ft.fmt.format(self, format, args);
         }
 
-        pub fn flush(self: *Self) Error!void {
+        pub fn internal_flush(self: *Self) Error!void {
             _ = try callback(self.context, self.buffer[0..self.index]);
             self.index = 0;
         }
 
+        pub fn flush(self: *Self) Error!void {
+            self.lock.acquire();
+            defer self.lock.release();
+
+            try self.internal_flush();
+        }
+
         pub fn write(self: *Self, bytes: []const u8) Error!usize {
             if (bytes.len +| self.index > self.buffer.len) {
-                try self.flush();
+                try self.internal_flush();
                 return callback(self.context, bytes);
             } else {
                 for (bytes) |b| {
                     self.buffer[self.index] = b;
                     self.index += 1;
                     if (b == '\n')
-                        try self.flush();
+                        try self.internal_flush();
                 }
                 return bytes.len;
             }
         }
 
         pub fn writeAll(self: *Self, bytes: []const u8) Error!void {
+            self.lock.acquire();
+            defer self.lock.release();
+
             var offset: usize = 0;
             while (offset != bytes.len) {
                 offset += try self.write(bytes[offset..]);
@@ -48,6 +63,9 @@ pub fn BufferWriter(
         }
 
         pub fn writeByte(self: *Self, byte: u8) Error!void {
+            self.lock.acquire();
+            defer self.lock.release();
+
             _ = try self.write(&([1]u8{byte}));
         }
     };


### PR DESCRIPTION
## UPDATE semaphore: (f12fdcff026d01c5ec2dde86a529ec5f4f8dbc1d)

Add a check to avoid to block non-existing task during early boot stage.

## UPDATE Cache allocator: (2849235a22710591d3191df762259ba34e166848) 

Move all the critical logic to unsafe methods and add some mutex making cache thread safe.

## UPDATE wait_queue: (616e49a2fb6fe1aa1afd33ed4e8e7963d4e0a0ce) 

Embed the wait-queue node in the TaskDescriptor allow us to not use some allocator anymore.

This decision is due to bootstrapping problem:
- We want to protect our allocators with mutexes
- mutexes uses wait-queues
- wait-queue needs to allocate nodes
- the allocator will use mutexes ...

## UPDATE page_frame_allocator: (69c2fe719afaf38da317f1418c24f18677e3e683) 

Make page frame allocator thread safe.

## UPDATE buffer_writer: (56f9d24d7b1215a5ce2984b659fba8713030d36c) 

Make buffer_writer thread safe.

## UPDATE virtual_space: (29e6abd6e4a602030d1c6f405ae8b315a9f7ec6f) 

Make virtual_space thread safe.