### PR TITLE
add wait syscall

### DIFF
--- a/src/interrupts.zig
+++ b/src/interrupts.zig
@@ -264,10 +264,10 @@ export fn wrapper(
 
     f(frame.*);
 
-    setup_iret_frame(frame);
-
-    if (privilege_transition)
+    if (privilege_transition) {
+        setup_iret_frame(frame);
         frame.* = scheduler.get_current_task().ucontext.uc_mcontext;
+    }
 
     if (!interrupt_enable)
         scheduler.lock_count -|= 1;

--- a/src/memory/page_fault.zig
+++ b/src/memory/page_fault.zig
@@ -71,7 +71,7 @@ fn kernel_page_fault(fault: PageFault) void {
 }
 
 fn segmentation_fault(task: *TaskDescriptor, fault: PageFault) void {
-    task.signalManager.queue_signal(.{
+    task.send_signal(.{
         .si_signo = .{ .valid = .SIGSEGV },
         .si_code = if (fault.present) .SEGV_ACCERR else .SEGV_MAPERR,
         .si_pid = 0,

--- a/src/memory/page_fault.zig
+++ b/src/memory/page_fault.zig
@@ -72,7 +72,7 @@ fn kernel_page_fault(fault: PageFault) void {
 
 fn segmentation_fault(task: *TaskDescriptor, fault: PageFault) void {
     task.signalManager.queue_signal(.{
-        .si_signo = .SIGSEGV,
+        .si_signo = .{ .valid = .SIGSEGV },
         .si_code = if (fault.present) .SEGV_ACCERR else .SEGV_MAPERR,
         .si_pid = 0,
         .si_addr = fault.faulting_address,

--- a/src/misc/philosophers.zig
+++ b/src/misc/philosophers.zig
@@ -148,6 +148,7 @@ pub fn main(nb: u8, ttd: usize, tte: usize, tts: usize) void {
             current_pid,
             .CHILD,
             &stat,
+            null,
             .{},
         ) catch ft.log.warn("Failed to wait for philosopher {}", .{philo.id});
     }

--- a/src/misc/philosophers.zig
+++ b/src/misc/philosophers.zig
@@ -60,7 +60,7 @@ pub const Philosopher = struct {
         self.last_meal = get_time_since_boot() - start_time;
         self.check_eos();
         tty.printk("{} {} is eating\n", .{ self.last_meal, self.id });
-        @import("../task/sleep.zig").sleep(time_to_eat);
+        @import("../task/sleep.zig").sleep(time_to_eat) catch {};
     }
 
     fn check_eos(self: *Self) void {
@@ -83,7 +83,7 @@ fn philosopher_task(data: usize) u8 {
     const philosopher: *Philosopher = @ptrFromInt(data);
 
     if (philosopher.id % 2 == 1) {
-        @import("../task/sleep.zig").sleep(time_to_eat / 2);
+        @import("../task/sleep.zig").sleep(time_to_eat / 2) catch {};
     }
 
     while (true) {
@@ -92,7 +92,7 @@ fn philosopher_task(data: usize) u8 {
         philosopher.drop_forks();
         philosopher.check_eos();
         tty.printk("{} {} is sleeping\n", .{ get_time_since_boot() - start_time, philosopher.id });
-        @import("../task/sleep.zig").sleep(time_to_sleep);
+        @import("../task/sleep.zig").sleep(time_to_sleep) catch {};
         philosopher.check_eos();
         tty.printk("{} {} is thinking\n", .{ get_time_since_boot() - start_time, philosopher.id });
     }

--- a/src/shell/Shell.zig
+++ b/src/shell/Shell.zig
@@ -126,7 +126,7 @@ pub fn Shell(comptime _builtins: anytype) type {
             var i: u32 = 0;
             while (i < self.jobs.slice.len) {
                 const job = self.jobs.slice[i];
-                if (wait.wait(job.pid, .SELF, &status, .{ .WNOHANG = true }) catch @panic("todo")) |_| {
+                if ((wait.wait(job.pid, .SELF, &status, null, .{ .WNOHANG = true }) catch 1) != 0) {
                     self.print("[{}] done {s}\n", .{ job.pid, job.command_line });
                     allocator.destroy(job.command_line);
                     _ = self.jobs.swapRemove(i);

--- a/src/shell/default/builtins.zig
+++ b/src/shell/default/builtins.zig
@@ -285,7 +285,7 @@ pub fn vfuzz(shell: anytype, args: [][]u8) CmdError!void {
 pub fn sleep(_: anytype, args: [][]u8) CmdError!void {
     if (args.len != 2) return CmdError.InvalidNumberOfArguments;
     const ms = ft.fmt.parseInt(u64, args[1], 0) catch return CmdError.InvalidParameter;
-    @import("../../task/sleep.zig").sleep(ms);
+    @import("../../task/sleep.zig").sleep(ms) catch {};
 }
 
 pub fn wait(_: anytype, _: [][]u8) CmdError!void {

--- a/src/syscall.zig
+++ b/src/syscall.zig
@@ -109,7 +109,11 @@ fn call_syscall(comptime code: Code) void {
 
     switch (comptime syscall_type) {
         .do => {
-            const ret = @call(.auto, sys_struct.do, get_params(
+            const ret_type = if (@typeInfo(@TypeOf(sys_struct.do)).@"fn".return_type) |return_type|
+                if (@typeInfo(return_type) == .error_union) return_type else errno.Errno!return_type
+            else
+                errno.Errno!void;
+            const ret: ret_type = @call(.auto, sys_struct.do, get_params(
                 @typeInfo(@TypeOf(sys_struct.do)).@"fn",
                 current_task.ucontext.uc_mcontext,
             ));

--- a/src/syscall/kill.zig
+++ b/src/syscall/kill.zig
@@ -11,7 +11,7 @@ pub fn do(pid: task.TaskDescriptor.Pid, id: signal.Id) !void {
         const descriptor = task_set.get_task_descriptor(pid) orelse return Errno.ESRCH;
         // todo permisssion
         descriptor.signalManager.queue_signal(.{
-            .si_signo = id,
+            .si_signo = .{ .valid = id },
             .si_code = .SI_USER,
             .si_pid = scheduler.get_current_task().pid,
             // todo set more fields of siginfo

--- a/src/syscall/kill.zig
+++ b/src/syscall/kill.zig
@@ -10,7 +10,7 @@ pub fn do(pid: task.TaskDescriptor.Pid, id: signal.Id) !void {
     if (pid > 0) {
         const descriptor = task_set.get_task_descriptor(pid) orelse return Errno.ESRCH;
         // todo permisssion
-        descriptor.signalManager.queue_signal(.{
+        descriptor.send_signal(.{
             .si_signo = .{ .valid = id },
             .si_code = .SI_USER,
             .si_pid = scheduler.get_current_task().pid,

--- a/src/syscall/wait.zig
+++ b/src/syscall/wait.zig
@@ -1,0 +1,9 @@
+const wait = @import("../task/wait.zig");
+const task = @import("../task/task.zig");
+const Pid = task.TaskDescriptor.Pid;
+
+pub const Id = 16;
+
+pub fn do(stat_loc: ?*wait.Status) !Pid {
+    return @import("waitpid.zig").do(-1, stat_loc, @bitCast(@as(i32, 0)));
+}

--- a/src/syscall/waitpid.zig
+++ b/src/syscall/waitpid.zig
@@ -1,0 +1,18 @@
+const scheduler = @import("../task/scheduler.zig");
+const task = @import("../task/task.zig");
+const Pid = task.TaskDescriptor.Pid;
+const wait = @import("../task/wait.zig");
+
+pub const Id = 17;
+
+pub fn do(pid: Pid, stat_loc: ?*wait.Status, options: wait.WaitOptions) !Pid {
+    if (pid == -1) {
+        return wait.wait(scheduler.get_current_task().pid, .CHILD, stat_loc, null, options);
+    } else if (pid > 0) {
+        return wait.wait(pid, .SELF, stat_loc, null, options);
+    } else if (pid == 0) {
+        @panic("todo Process groups not implemented");
+    } else {
+        @panic("todo Process groups not implemented");
+    }
+}

--- a/src/task/semaphore.zig
+++ b/src/task/semaphore.zig
@@ -24,7 +24,7 @@ pub fn Semaphore(max_count: u32) type {
                 self.count += 1;
             } else {
                 if (!scheduler.is_initialized()) @panic("Max count reached for a semaphore during early boot stage");
-                self.queue.block(scheduler.get_current_task(), null);
+                self.queue.block_no_int(scheduler.get_current_task(), null);
                 scheduler.schedule();
             }
         }

--- a/src/task/signal.zig
+++ b/src/task/signal.zig
@@ -83,6 +83,9 @@ pub const siginfo_t = extern struct {
         pub fn unwrap(self: @This()) Id {
             return if (@as(u32, @bitCast(self)) == 0) @panic("invalid signo") else self.valid;
         }
+        pub fn safeUnwrap(self: @This()) ?Id {
+            return if (@as(u32, @bitCast(self)) == 0) null else self.valid;
+        }
     };
 };
 

--- a/src/task/sleep.zig
+++ b/src/task/sleep.zig
@@ -15,20 +15,19 @@ pub fn try_unblock_sleeping_task() void {
     sleep_queue.try_unblock();
 }
 
-pub fn usleep(micro: u64) void {
+pub fn usleep(micro: u64) !void {
     scheduler.lock();
     defer scheduler.unlock();
 
     const t = scheduler.get_current_task();
     var sleep_timeout: u64 = pit.get_utime_since_boot() + micro;
 
-    sleep_queue.block(t, @ptrCast(&sleep_timeout));
-    scheduler.schedule();
+    try sleep_queue.block(t, @ptrCast(&sleep_timeout));
 }
 
-pub fn sleep(millis: u64) void {
+pub fn sleep(millis: u64) !void {
     scheduler.lock();
     defer scheduler.unlock();
 
-    usleep(millis * 1000);
+    return usleep(millis * 1000);
 }

--- a/src/task/status_informations.zig
+++ b/src/task/status_informations.zig
@@ -9,4 +9,26 @@ pub const Status = struct {
         Continued = 1,
         Terminated = 2,
     };
+
+    pub const TransitionMask = packed struct(u3) {
+        Stopped: bool = false,
+        Continued: bool = false,
+        Terminated: bool = false,
+
+        pub const Self = @This();
+
+        pub fn add(self: *Self, transition: Transition) void {
+            @field(self.*, @tagName(transition)) = true;
+        }
+
+        pub fn remove(self: *Self, transition: Transition) void {
+            @field(self.*, @tagName(transition)) = false;
+        }
+
+        pub fn check(self: Self, transition: Transition) bool {
+            return switch (transition) {
+                inline else => |t| @field(self, @tagName(t)),
+            };
+        }
+    };
 };

--- a/src/task/status_stack.zig
+++ b/src/task/status_stack.zig
@@ -52,7 +52,13 @@ pub const StatusStack = struct {
         } else return null;
     }
 
-    pub fn top(self: Self, transition: Status.Transition) ?*Node {
-        return self.lists[@intFromEnum(transition)];
+    pub fn top(self: Self, mask: Status.TransitionMask) ?*Node {
+        for (self.lists, 0..) |list, i| {
+            if (mask.check(@enumFromInt(i))) {
+                if (list) |n|
+                    return n;
+            }
+        }
+        return null;
     }
 };

--- a/src/task/task.zig
+++ b/src/task/task.zig
@@ -76,6 +76,7 @@ pub const TaskDescriptor = struct {
         if (self.vm) |_| {
             // todo destroy vm
         }
+        self.status_wait_queue.unblock_all();
         wait_queue.force_remove(self);
         if (self.parent) |p| {
             p.status_stack.remove(&self.status_stack_process_node);

--- a/src/task/task.zig
+++ b/src/task/task.zig
@@ -154,7 +154,7 @@ pub const TaskDescriptor = struct {
     }
 
     fn handle_default_action(self: *Self, sig: signal.siginfo_t) void {
-        switch (self.signalManager.get_defaultAction(sig.si_signo)) {
+        switch (self.signalManager.get_defaultAction(sig.si_signo.unwrap())) {
             .Ignore => {},
             .Terminate => {
                 self.state = .Zombie;
@@ -200,7 +200,8 @@ pub const TaskDescriptor = struct {
         const bytecode_begin = ucontext.put_data_on_stack(&self.ucontext, bytecode).ptr;
 
         if (!action.sa_flags.SA_NODEFER) {
-            self.ucontext.uc_sigmask |= @as(signal.SigSet, 1) << @as(u5, @intCast(@intFromEnum(info.si_signo)));
+            self.ucontext.uc_sigmask |=
+                @as(signal.SigSet, 1) << @as(u5, @intCast(@intFromEnum(info.si_signo.unwrap())));
         }
 
         self.ucontext.uc_sigmask |= action.sa_mask;
@@ -235,7 +236,7 @@ pub const TaskDescriptor = struct {
 
     pub fn handle_signal(self: *Self) void {
         while (self.signalManager.get_pending_signal(self.ucontext.uc_sigmask)) |info| {
-            const id: signal.Id = info.si_signo;
+            const id: signal.Id = info.si_signo.unwrap();
             const action = self.signalManager.get_action(id);
             self.do_action(action, info);
         }

--- a/src/task/task.zig
+++ b/src/task/task.zig
@@ -33,6 +33,7 @@ pub const TaskDescriptor = struct {
 
     vm: ?*VirtualSpace = null,
 
+    status_wait_queue: @import("wait.zig").WaitQueue = .{},
     status_info: ?status_informations.Status = null,
     status_stack: StatusStack = .{},
     status_stack_process_node: StatusStack.Node = .{},
@@ -100,6 +101,7 @@ pub const TaskDescriptor = struct {
         if (new_status_info) |s| {
             if (self.parent) |p| {
                 p.status_stack.add(&self.status_stack_process_node, s.transition);
+                p.status_wait_queue.try_unblock();
             }
             // todo: process group
         } else @panic("todo");

--- a/src/task/task.zig
+++ b/src/task/task.zig
@@ -137,17 +137,17 @@ pub const TaskDescriptor = struct {
         return ret;
     }
 
-    pub fn autowait(self: *Self, transition: status_informations.Status.Transition) Errno!?*Self {
+    pub fn autowait(self: *Self, mask: status_informations.Status.TransitionMask) ?*Self {
         if (self.status_info) |s| {
-            if (s.transition != transition) {
+            if (!mask.check(s.transition)) {
                 return null;
             }
             return self;
         } else return null;
     }
 
-    pub fn wait_child(self: *Self, transition: status_informations.Status.Transition) Errno!?*Self {
-        if (self.status_stack.top(transition)) |n| {
+    pub fn wait_child(self: *Self, mask: status_informations.Status.TransitionMask) ?*Self {
+        if (self.status_stack.top(mask)) |n| {
             const descriptor: *Self = @alignCast(@fieldParentPtr("status_stack_process_node", n));
             return descriptor;
         } else return null;

--- a/src/task/task.zig
+++ b/src/task/task.zig
@@ -48,14 +48,11 @@ pub const TaskDescriptor = struct {
     rq_node: ready_queue.Node = .{ .data = false },
     wq_node: wait_queue.Node = .{ .data = null },
 
-    sleep_timeout: u64 = 0,
-
     pub const State = enum(u8) {
         Running,
         Blocked,
         Ready,
         Stopped,
-        Sleeping,
         Zombie,
     };
     pub const Pid = i32;

--- a/src/task/task_set.zig
+++ b/src/task/task_set.zig
@@ -42,7 +42,7 @@ fn next_pid() ?TaskDescriptor.Pid {
 }
 
 pub fn get_task_descriptor(pid: TaskDescriptor.Pid) ?*TaskDescriptor {
-    if (pid < 0) return null;
+    if (pid < 0 or pid >= list.len) return null;
     return list[@intCast(pid)];
 }
 

--- a/src/task/wait.zig
+++ b/src/task/wait.zig
@@ -34,7 +34,7 @@ pub const Status = packed struct(u32) {
         return switch (si.transition) {
             status_informations.Status.Transition.Stopped => .{
                 .type = Type.Stopped,
-                .value = @intCast(@intFromEnum(si.siginfo.si_signo)),
+                .value = @intCast(@intFromEnum(si.siginfo.si_signo.unwrap())),
             },
             status_informations.Status.Transition.Continued => .{
                 .type = Type.Continued,
@@ -42,7 +42,7 @@ pub const Status = packed struct(u32) {
             },
             status_informations.Status.Transition.Terminated => if (si.signaled) .{
                 .type = Type.Signaled,
-                .value = @intCast(@intFromEnum(si.siginfo.si_signo)),
+                .value = @intCast(@intFromEnum(si.siginfo.si_signo.unwrap())),
             } else .{
                 .type = Type.Exited,
                 .value = @truncate(si.siginfo.si_status),

--- a/src/task/wait.zig
+++ b/src/task/wait.zig
@@ -54,7 +54,7 @@ pub const Status = packed struct(u32) {
 fn wait_selector(
     descriptor: *TaskDescriptor,
     selector: Selector,
-    transition: status_informations.Status.Transition,
+    transition: status_informations.Status.TransitionMask,
 ) Errno!?*TaskDescriptor {
     return switch (selector) {
         .SELF => descriptor.autowait(transition),
@@ -66,15 +66,15 @@ fn wait_transition(descriptor: *TaskDescriptor, selector: Selector, options: Wai
     return try wait_selector(
         descriptor,
         selector,
-        .Terminated,
+        .{ .Terminated = true },
     ) orelse (if (options.WCONTINUED) try wait_selector(
         descriptor,
         selector,
-        .Continued,
+        .{ .Continued = true },
     ) else null) orelse (if (options.WUNTRACED) try wait_selector(
         descriptor,
         selector,
-        .Stopped,
+        .{ .Stopped = true },
     ) else null);
 }
 

--- a/src/task/wait.zig
+++ b/src/task/wait.zig
@@ -6,12 +6,13 @@ const task_set = @import("task_set.zig");
 const signal = @import("signal.zig");
 const Errno = @import("../errno.zig").Errno;
 const status_informations = @import("status_informations.zig");
+const wait_queues = @import("wait_queue.zig");
 
 pub const WaitOptions = packed struct(u32) {
     WCONTINUED: bool = false,
     WNOHANG: bool = false,
     WUNTRACED: bool = false,
-    _unused: u29 = undefined,
+    _unused: u29 = 0,
 };
 
 pub const Selector = enum {
@@ -34,7 +35,7 @@ pub const Status = packed struct(u32) {
         return switch (si.transition) {
             status_informations.Status.Transition.Stopped => .{
                 .type = Type.Stopped,
-                .value = @intCast(@intFromEnum(si.siginfo.si_signo.unwrap())),
+                .value = @intCast(@as(u32, @intFromEnum(si.siginfo.si_signo.unwrap()))),
             },
             status_informations.Status.Transition.Continued => .{
                 .type = Type.Continued,
@@ -42,7 +43,7 @@ pub const Status = packed struct(u32) {
             },
             status_informations.Status.Transition.Terminated => if (si.signaled) .{
                 .type = Type.Signaled,
-                .value = @intCast(@intFromEnum(si.siginfo.si_signo.unwrap())),
+                .value = @intCast(@as(u32, @intFromEnum(si.siginfo.si_signo.unwrap()))),
             } else .{
                 .type = Type.Exited,
                 .value = @truncate(si.siginfo.si_status),
@@ -51,63 +52,99 @@ pub const Status = packed struct(u32) {
     }
 };
 
-fn wait_selector(
-    descriptor: *TaskDescriptor,
+const WaitRequest = struct {
     selector: Selector,
-    transition: status_informations.Status.TransitionMask,
-) Errno!?*TaskDescriptor {
-    return switch (selector) {
-        .SELF => descriptor.autowait(transition),
-        .CHILD => descriptor.wait_child(transition),
+    transition_mask: status_informations.Status.TransitionMask,
+    pid: TaskDescriptor.Pid,
+};
+
+fn predicate(_: *void, wait_request_ptr: ?*void) bool {
+    const wait_request = @as(*WaitRequest, @alignCast(@ptrCast(wait_request_ptr.?))).*;
+    const waited_task = task_set.get_task_descriptor(wait_request.pid) orelse return true;
+
+    return switch (wait_request.selector) {
+        .SELF => waited_task.autowait(wait_request.transition_mask) != null,
+        .CHILD => waited_task.wait_child(wait_request.transition_mask) != null,
     };
 }
 
-fn wait_transition(descriptor: *TaskDescriptor, selector: Selector, options: WaitOptions) Errno!?*TaskDescriptor {
-    return try wait_selector(
-        descriptor,
-        selector,
-        .{ .Terminated = true },
-    ) orelse (if (options.WCONTINUED) try wait_selector(
-        descriptor,
-        selector,
-        .{ .Continued = true },
-    ) else null) orelse (if (options.WUNTRACED) try wait_selector(
-        descriptor,
-        selector,
-        .{ .Stopped = true },
-    ) else null);
+pub const WaitQueue = wait_queues.WaitQueue(.{
+    .predicate = predicate,
+});
+
+pub fn get_task_nohang(
+    descriptor: *TaskDescriptor,
+    request: WaitRequest,
+    selector: Selector,
+) ?*TaskDescriptor {
+    return switch (selector) {
+        .SELF => descriptor.autowait(request.transition_mask),
+        .CHILD => descriptor.wait_child(request.transition_mask),
+    };
+}
+
+pub fn get_task(
+    descriptor: *TaskDescriptor,
+    request: WaitRequest,
+    selector: Selector,
+) ?*TaskDescriptor {
+    var var_request = request;
+    scheduler.get_current_task().status_wait_queue.block(scheduler.get_current_task(), @ptrCast(&var_request));
+    return get_task_nohang(descriptor, request, selector);
 }
 
 pub fn wait(
     pid: TaskDescriptor.Pid,
     selector: Selector,
-    stat_loc: *Status,
+    stat_loc: ?*Status,
+    siginfo: ?*signal.siginfo_t,
     options: WaitOptions,
-) Errno!?TaskDescriptor.Pid {
-    // todo: check if this is the right errno
+) Errno!TaskDescriptor.Pid {
     const descriptor = task_set.get_task_descriptor(pid) orelse return Errno.ECHILD;
     if (options._unused != 0) {
         return Errno.EINVAL;
     }
-    // todo ESRCH
-    // const current_task = scheduler.get_current_task();
-    // if (descriptor.parent != current_task) {
-    //     return error.InvalidPid; // todo: check perm
-    // }
-    while (true) {
-        if (try wait_transition(descriptor, selector, options)) |d| {
-            const status_info = d.get_status() orelse unreachable;
-            stat_loc.* = Status.from_status_info(status_info);
-            const ret = d.pid;
-            if (status_info.transition == .Terminated) {
-                task_set.destroy_task(d.pid) catch @panic("todo");
-            }
-            return ret;
-        }
-        if (options.WNOHANG) {
-            return null;
-        }
-        @import("../cpu.zig").halt();
-        // todo signals
+    if ((selector == .CHILD and descriptor.childs == null) or
+        (selector == .SELF and descriptor.parent != scheduler.get_current_task()))
+    {
+        return Errno.ECHILD;
     }
+
+    const request = WaitRequest{ .selector = selector, .pid = pid, .transition_mask = .{
+        .Continued = options.WCONTINUED,
+        .Stopped = options.WUNTRACED,
+        .Terminated = true,
+    } };
+
+    const waited_task: *TaskDescriptor = switch (options.WNOHANG) {
+        true => get_task_nohang(descriptor, request, selector) orelse {
+            if (siginfo) |s| {
+                s.* = .{
+                    .si_pid = 0,
+                    .si_signo = signal.siginfo_t.Signo.invalid,
+                };
+            }
+            return 0;
+        },
+        false => get_task(descriptor, request, selector) orelse return Errno.EINTR,
+    };
+
+    // if (options.WNOWAIT)
+    //     return waited_task.pid;
+
+    const status_info = waited_task.get_status() orelse @panic("todo: task waited but no status");
+
+    if (stat_loc) |sl|
+        sl.* = Status.from_status_info(status_info);
+
+    if (siginfo) |s| {
+        s.* = status_info.siginfo;
+        s.*.si_signo = .{ .valid = .SIGCHLD };
+    }
+
+    defer if (status_info.transition == .Terminated) {
+        task_set.destroy_task(waited_task.pid) catch @panic("todo: failed to destroy task");
+    };
+
+    return waited_task.pid;
 }

--- a/src/task/wait.zig
+++ b/src/task/wait.zig
@@ -87,9 +87,9 @@ pub fn get_task(
     descriptor: *TaskDescriptor,
     request: WaitRequest,
     selector: Selector,
-) ?*TaskDescriptor {
+) !?*TaskDescriptor {
     var var_request = request;
-    scheduler.get_current_task().status_wait_queue.block(scheduler.get_current_task(), @ptrCast(&var_request));
+    try scheduler.get_current_task().status_wait_queue.block(scheduler.get_current_task(), @ptrCast(&var_request));
     return get_task_nohang(descriptor, request, selector);
 }
 
@@ -126,7 +126,7 @@ pub fn wait(
             }
             return 0;
         },
-        false => get_task(descriptor, request, selector) orelse return Errno.EINTR,
+        false => try get_task(descriptor, request, selector) orelse return Errno.EINTR,
     };
 
     // if (options.WNOWAIT)

--- a/src/task/wait_queue.zig
+++ b/src/task/wait_queue.zig
@@ -72,6 +72,21 @@ pub fn WaitQueue(arg: WaitQueueArg) type {
                 node = next;
             }
         }
+
+        pub fn unblock_all(self: *Self) void {
+            scheduler.lock();
+            defer scheduler.unlock();
+
+            var node = self.queue.first;
+            while (node) |n| {
+                const task: *TaskDescriptor = @alignCast(@fieldParentPtr("wq_node", n));
+                const next = n.next;
+                ready_queue.push(task);
+                self.queue.remove(n);
+                if (arg.unblock_callback) |callback| callback(@alignCast(@ptrCast(task)), n.data);
+                node = next;
+            }
+        }
     };
 }
 

--- a/src/task/wait_queue.zig
+++ b/src/task/wait_queue.zig
@@ -6,30 +6,37 @@ const Queue = @import("ft").DoublyLinkedList(?*void);
 
 pub const Node = Queue.Node;
 
+// todo: change *void to *TaskDescriptor when https://github.com/ziglang/zig/issues/14353 is fixed
 const WaitQueueArg = struct {
     /// Callback to be called when a task is added to the wait queue.
-    block_callback: ?fn (*TaskDescriptor) void = null,
+    block_callback: ?fn (*void, ?*void) void = null,
 
     /// Predicate to determine if a task should be unblocked.
-    predicate: fn (*TaskDescriptor) bool,
+    predicate: fn (*void, ?*void) bool,
 
     /// Callback to be called when a task is unblocked.
-    unblock_callback: ?fn (*TaskDescriptor) void = null,
+    unblock_callback: ?fn (*void, ?*void) void = null,
 };
 
 pub fn WaitQueue(arg: WaitQueueArg) type {
     return struct {
-        const Self = @This();
-
         queue: Queue = .{},
 
-        pub fn block(self: *Self, task: *TaskDescriptor) void {
+        const Self = @This();
+
+        pub fn block(self: *Self, task: *TaskDescriptor, data: ?*void) void {
             scheduler.lock();
             defer scheduler.unlock();
+			if (arg.predicate(@alignCast(@ptrCast(task)), data))
+				return;
 
             const node: *Node = &task.wq_node;
+
+            node.data = data;
             self.queue.append(node);
-            if (arg.block_callback) |callback| callback(task);
+            if (arg.block_callback) |callback| callback(@alignCast(@ptrCast(task)), node.data);
+            task.state = .Blocked;
+            scheduler.schedule();
         }
 
         pub fn try_unblock(self: *Self) void {
@@ -40,10 +47,10 @@ pub fn WaitQueue(arg: WaitQueueArg) type {
             while (node) |n| {
                 const task: *TaskDescriptor = @alignCast(@fieldParentPtr("wq_node", n));
                 const next = n.next;
-                if (arg.predicate(task)) {
+                if (arg.predicate(@alignCast(@ptrCast(task)), n.data)) {
                     ready_queue.push(task);
                     self.queue.remove(n);
-                    if (arg.unblock_callback) |callback| callback(task);
+                    if (arg.unblock_callback) |callback| callback(@alignCast(@ptrCast(task)), n.data);
                 }
                 node = next;
             }


### PR DESCRIPTION
## REWORK wait_queue: (34879592b10f91cb62cf1e9f528a43bc69e06273)

- add a data argument
- call the predicate before inserting the node in the waitqueue
- remove the sleeping state
- change task state and schedule directly in wait_queue.block

## FIX task_set: (118e9ffda25f27149b0a9000b7e6177bf57fccf3)

get_task_descriptor return null if pid is outside the table

## REWORK status_stack: (74b316f6e8da24c2eea4f5271a7ca5781d1a3f67)

use masks to find status.

## REWORK signal: (aa83c7b09fa565ee58cef3349ace1d315f1345f3)

create a monad to wrap si_signo

## REWORK SignalManager: (872023a6c2bbea060e7d159b6e7836894fda233f)

make SignalManager thread-safe by adding a mutex

## REWORK wait: (14bd03e503abe63e232dd453b093085654f1a6fb)

use a wait_queue when waiting a child process

## ADD wait and waitpid syscall (8f9e66ae4ecfcfa4a1232ddb8f96f7e135b54cfd)

## FIX stop/continue: (691232dbc59c84ef48ea8aa2fea1426ee6d00ea8)

- add interruptible wait_queues
- handle terminating signal
- handle sig continue

## REWORK wait_queue: (455da228bbe01646553e4c7ae9d11dc7831e3eec)

add an unblock_all function to unblock all task waiting in a queue

## FIX tasks: (eda8799dac128f7dbbbce7971293daa758065226)

deinit virtual space