### PR TITLE
ADD block device framework and RAMdisk device driver:

### DIFF
--- a/src/block/block.zig
+++ b/src/block/block.zig
@@ -1,0 +1,90 @@
+const std = @import("std");
+
+pub const Partition = @import("partition.zig");
+
+pub const STANDARD_BLOCK_SIZE = 512;
+
+pub const GenDisk = @import("gendisk.zig");
+
+pub const translator = @import("translator.zig");
+pub const BlockTranslator = translator.BlockTranslator;
+pub const ScaledTranslator = translator.ScaledTranslator;
+pub const IdentityTranslator = translator.IdentityTranslator;
+
+pub const major_t = u8;
+pub const minor_t = u8;
+
+pub const dev_t = packed struct {
+    minor: minor_t,
+    major: major_t,
+
+    pub fn toInt(self: dev_t) udev_t {
+        return @bitCast(self);
+    }
+
+    pub fn fromInt(value: udev_t) dev_t {
+        return @bitCast(value);
+    }
+};
+
+// Unsigned version of dev_t
+pub const udev_t = std.meta.Int(.unsigned, @bitSizeOf(dev_t));
+
+pub const Features = packed struct {
+    readonly: bool = true,
+    ext_devt: bool = false, // Supports extended dev_t
+    removable: bool = false,
+    flushable: bool = false,
+    trimable: bool = false,
+};
+
+pub const Statistics = struct {
+    reads_completed: u64 = 0,
+    writes_completed: u64 = 0,
+    blocks_read: u64 = 0,
+    blocks_written: u64 = 0,
+    errors: u64 = 0,
+    // TODO: Implements LRU cache
+    cache_hits: u64 = 0,
+    cache_misses: u64 = 0,
+};
+
+pub const BlockError = error{
+    DeviceNotFound,
+    AlreadyExists,
+    BufferTooSmall,
+    OutOfBounds,
+    WriteProtected,
+    NotSupported,
+    IoError,
+    NoFreeBuffers,
+    InvalidOperation,
+    MediaNotPresent,
+    DeviceBusy,
+    CorruptedData,
+    OutOfMemory,
+};
+
+pub const IOType = enum { Read, Write };
+
+/// Function type for performing physical I/O operations
+pub const PhysicalIOFn = *const fn (
+    context: *anyopaque,
+    physical_block: u32,
+    count: u32,
+    buffer: []u8,
+    operation: IOType,
+) BlockError!void;
+
+pub const Operations = struct {
+    /// Physical I/O operation - operates on device's native block size
+    physical_io: PhysicalIOFn,
+    destroy: *const fn (*GenDisk) void,
+
+    // /// Optional operations
+    // flush: ?*const fn (dev: *BlockDevice) BlockError!void = null,
+    // trim: ?*const fn (dev: *BlockDevice, start_block: u32, count: u32) BlockError!void = null,
+    // media_changed: ?*const fn (dev: *BlockDevice) bool = null,
+    // revalidate: ?*const fn (dev: *BlockDevice) BlockError!void = null,
+    // generate_name: ?*const fn (dev: *BlockDevice) []const u8 = null,
+};

--- a/src/block/gendisk.zig
+++ b/src/block/gendisk.zig
@@ -1,0 +1,112 @@
+const std = @import("std");
+
+const registry = @import("registry.zig");
+
+const core = @import("block.zig");
+const Features = core.Features;
+const Partition = core.Partition;
+const Operations = core.Operations;
+const dev_t = core.dev_t;
+const major_t = core.major_t;
+const minor_t = core.minor_t;
+
+const PartitionList = std.ArrayList(*Partition);
+
+const allocator = @import("../memory.zig").bigAlloc.allocator();
+
+const DISK_NAME_LEN = 16;
+
+const Self = @This();
+
+// name of whole disk
+name: [DISK_NAME_LEN:0]u8,
+major: major_t,
+
+// number of minors (whole disk + partitions)
+// if =1, the disk can't be partitioned
+minors: minor_t,
+first_minor: minor_t,
+max_transfer: u16, // Maximum logical blocks per transfer
+features: Features,
+partition_table: PartitionList = .empty,
+vtable: ?*const Operations,
+private_data: ?*void = null,
+sector_size: u32 = 512, // Physical sector size in bytes
+
+pub fn create(minors: minor_t) !*Self {
+    const disk: *Self = try allocator.create(Self);
+
+    disk.* = .{
+        .name = .{0} ** DISK_NAME_LEN,
+        .major = 0,
+        .minors = minors,
+        .first_minor = 0,
+        .features = .{},
+        .max_transfer = 0,
+        .vtable = null,
+        .private_data = null,
+    };
+    return disk;
+}
+
+pub fn destroy(self: *Self) void {
+    for (self.partition_table.items) |partition| {
+        registry.unregister_device(partition.devt);
+        partition.destroy();
+        allocator.destroy(partition);
+    }
+    self.partition_table.deinit(allocator);
+    if (self.vtable) |vtable| {
+        vtable.destroy(self);
+    }
+    allocator.destroy(self);
+}
+
+pub fn add_partition(self: *Self, offset: u32, limit: u32) !*Partition {
+    var name: [Partition.PART_NAME_LEN:0]u8 = .{0} ** (Partition.PART_NAME_LEN);
+
+    const name_len = std.mem.len(@as([*:0]const u8, &self.name));
+
+    const index = self.partition_table.items.len;
+    if (index > 0) {
+        _ = std.fmt.bufPrint(&name, "{s}{s}{}", .{
+            self.name[0..name_len],
+            if (std.ascii.isDigit(self.name[name_len - 1])) "p" else "",
+            index,
+        }) catch |e| {
+            std.log.err("Failed to format partition name: {s}", .{@errorName(e)});
+        };
+    } else {
+        name = self.name;
+    }
+
+    const partition: *Partition = try allocator.create(Partition);
+    errdefer allocator.destroy(partition);
+
+    partition.* = .{
+        .partno = @intCast(index),
+        .disk = self,
+        .name = name,
+        .readonly = false,
+        .translator = undefined,
+        .total_blocks = limit,
+    };
+
+    _ = try partition.alloc_devt();
+    errdefer partition.free_devt();
+
+    // Create the appropriate translator
+    partition.translator = try core.translator.create(allocator, self.sector_size);
+    errdefer partition.translator.deinit();
+
+    partition.translator.logical_offset = offset; // in logical blocks (512-byte blocks)
+    partition.translator.logical_limit = limit; // if null, no limit, up to the end of disk
+
+    const entry: **Partition = try self.partition_table.addOne(allocator);
+    entry.* = partition;
+    errdefer _ = self.partition_table.pop();
+
+    try registry.register_device(partition);
+
+    return partition;
+}

--- a/src/block/partition.zig
+++ b/src/block/partition.zig
@@ -1,0 +1,91 @@
+const std = @import("std");
+const logger = std.log.scoped(.block_device);
+
+const registry = @import("registry.zig");
+const core = @import("block.zig");
+const STANDARD_BLOCK_SIZE = core.STANDARD_BLOCK_SIZE;
+const BlockTranslator = core.BlockTranslator;
+const Statistics = core.Statistics;
+const BlockError = core.BlockError;
+const Operations = core.Operations;
+const dev_t = core.dev_t;
+
+pub const PART_NAME_LEN = 16;
+const GenDisk = @import("gendisk.zig");
+
+const errno = @import("../errno.zig").Errno;
+
+const Self = @This();
+
+devt: dev_t = .{ .major = 0, .minor = 0 },
+partno: core.minor_t,
+disk: *GenDisk,
+name: [PART_NAME_LEN]u8,
+total_blocks: u32, // Total logical blocks
+translator: *BlockTranslator, // Handles physical/logical translation
+stats: Statistics = .{},
+readonly: bool = false,
+
+/// Read logical blocks (always 512-byte blocks)
+pub fn read(self: *Self, start_block: u32, count: u32, buffer: []u8) BlockError!void {
+    if (buffer.len < count * STANDARD_BLOCK_SIZE) return BlockError.BufferTooSmall;
+    if (start_block + count > self.total_blocks) return BlockError.OutOfBounds;
+    if (self.disk.vtable == null) return BlockError.IoError;
+
+    errdefer self.stats.errors += 1;
+
+    // Use translator to handle the I/O
+    try self.translator.read(
+        start_block,
+        count,
+        buffer,
+        self.disk.vtable.?.physical_io,
+        self,
+    );
+
+    self.stats.reads_completed += 1;
+    self.stats.blocks_read += count;
+}
+
+/// Write logical blocks (always 512-byte blocks)
+pub fn write(self: *Self, start_block: u32, count: u32, buffer: []const u8) BlockError!void {
+    if (buffer.len < count * STANDARD_BLOCK_SIZE) return BlockError.BufferTooSmall;
+    if (start_block + count > self.total_blocks) return BlockError.OutOfBounds;
+    if (self.disk.vtable == null) return BlockError.IoError;
+    if (self.readonly or self.disk.features.readonly) return BlockError.WriteProtected;
+
+    errdefer self.stats.errors += 1;
+
+    // Use translator to handle the I/O
+    try self.translator.write(start_block, count, buffer, self.disk.vtable.?.physical_io, self);
+
+    self.stats.writes_completed += 1;
+    self.stats.blocks_written += count;
+}
+
+pub fn alloc_devt(self: *Self) !dev_t {
+    const disk = self.disk;
+
+    if (self.partno < disk.minors) {
+        self.devt = dev_t{ .major = disk.major, .minor = disk.first_minor + self.partno };
+        return self.devt;
+    }
+
+    const idx: core.minor_t = try registry.blkext_alloc_id();
+
+    self.devt = dev_t{ .major = registry.MAJOR, .minor = idx };
+    return self.devt;
+}
+
+pub fn free_devt(self: *Self) void {
+    if (self.devt.major == registry.MAJOR) {
+        registry.blkext_free_id(self.devt);
+        self.devt = .{ .major = 0, .minor = 0 };
+    }
+}
+
+/// Cleanup resources when device is destroyed
+pub fn destroy(self: *Self) void {
+    self.translator.deinit();
+    registry.blkext_free_id(self.devt);
+}

--- a/src/block/registry.zig
+++ b/src/block/registry.zig
@@ -1,0 +1,176 @@
+const std = @import("std");
+
+const core = @import("block.zig");
+const dev_t = core.dev_t;
+const udev_t = core.udev_t;
+const major_t = core.major_t;
+const minor_t = core.minor_t;
+
+const Errno = @import("../errno.zig").Errno;
+
+const allocator = @import("../memory.zig").smallAlloc.allocator();
+const MAX_MAJOR = std.math.maxInt(major_t);
+
+var majors: [MAX_MAJOR]?[]const u8 = .{null} ** MAX_MAJOR;
+
+pub const MAJOR: major_t = 254;
+
+var ida: struct {
+    const FreeList = std.ArrayList(minor_t);
+
+    next_id: minor_t = 0,
+    free_list: FreeList = .empty,
+} = .{};
+
+const Treap = std.Treap(*core.Partition, compare);
+const TreapNode = Treap.Node;
+
+pub fn compare(a: *core.Partition, b: *core.Partition) std.math.Order {
+    return std.math.order(a.devt.toInt(), b.devt.toInt());
+}
+
+var partitions = Treap{};
+
+pub fn register_block_dev(major: major_t, name: []const u8) !void {
+    if (majors[major]) |_| return Errno.EBUSY;
+    majors[major] = name;
+}
+
+pub fn blkext_alloc_id() !minor_t {
+    if (ida.free_list.items.len > 0) {
+        return ida.free_list.pop() orelse unreachable;
+    }
+    if (ida.next_id >= MAX_MAJOR) {
+        return Errno.ENOSPC;
+    }
+    const id = ida.next_id;
+    ida.next_id += 1;
+    return id;
+}
+
+pub fn blkext_free_id(devt: dev_t) void {
+    // If not an Extended block device, nothing to do
+    if (devt.major != MAJOR) return;
+
+    // Kernel panic if we can't keep track of the freed ID
+    _ = ida.free_list.append(allocator, devt.minor) catch
+        std.log.err("Failed to keep track of Extended block devices ({d})", .{devt.toInt()});
+}
+
+pub fn show_block_dev(writer: std.io.AnyWriter) void {
+    _ = writer.print("Block devices:\n", .{}) catch {};
+    for (majors, 0..) |name, major| {
+        if (name) |n| {
+            _ = writer.print("{d: >4} {s}\n", .{ major, n }) catch {};
+        }
+    }
+}
+
+pub fn show_partitions(writer: std.io.AnyWriter) void {
+    _ = writer.print(
+        "{s: <6}\t{s: <4}\t{s: <4}\t{s: <10}\t{s}\n",
+        .{ "id", "major", "minor", "#blocks", "name" },
+    ) catch {};
+
+    var it = partitions.inorderIterator();
+    while (it.next()) |entry| {
+        const part = entry.key;
+
+        if (part.partno != 0) continue;
+
+        for (part.disk.partition_table.items) |p| {
+            _ = writer.print(
+                "{d: >6}\t{d: >4}\t{d: >4}\t{d: >10}\t{s}\n",
+                .{
+                    p.devt.toInt(),
+                    p.devt.major,
+                    p.devt.minor,
+                    p.total_blocks,
+                    p.name,
+                },
+            ) catch {};
+        }
+    }
+}
+
+pub fn lookup_devt(name: []const u8, partno: minor_t) ?dev_t {
+    var it = partitions.inorderIterator();
+    while (it.next()) |entry| {
+        const part = entry.key;
+        const disk = part.disk;
+
+        const disk_name = std.mem.sliceTo(&disk.name, 0);
+
+        if (!std.mem.eql(u8, disk_name, name)) continue;
+
+        // the lookup devt returns the devt even if the partitions doesn't exist yet
+        if (partno < disk.minors) {
+            return dev_t{ .major = disk.major, .minor = disk.first_minor + partno };
+        }
+
+        if (partno >= disk.partition_table.items.len)
+            break;
+
+        return disk.partition_table.items[partno].devt;
+    }
+    return null;
+}
+
+pub fn get_partition(devt: dev_t) ?*core.Partition {
+    var dummy_part: core.Partition = undefined;
+    dummy_part.devt = devt;
+    const entry = partitions.getEntryFor(&dummy_part);
+    if (entry.node) |n| {
+        return n.key;
+    }
+    return null;
+}
+
+pub fn get_partition_by_name(name: []const u8) ?*core.Partition {
+    var it = partitions.inorderIterator();
+    while (it.next()) |entry| {
+        const part = entry.key;
+        if (std.mem.eql(u8, std.mem.sliceTo(&part.name, 0), name)) {
+            return part;
+        }
+    }
+    return null;
+}
+
+pub fn get_disk(devt: dev_t) ?*core.GenDisk {
+    if (get_partition(devt)) |part| {
+        return part.disk;
+    }
+    return null;
+}
+
+pub fn get_disk_by_name(name: []const u8) ?*core.GenDisk {
+    if (get_partition_by_name(name)) |part| {
+        return part.disk;
+    }
+    return null;
+}
+
+// The "block device" is mostly a vfs layer concept representing a partition
+// Actually every instance of "block device" is represented by a partition
+pub fn register_device(part: *core.Partition) !void {
+    var entry = partitions.getEntryFor(part);
+    if (entry.node) |_| return Errno.EEXIST;
+    const node: *TreapNode = allocator.create(TreapNode) catch return Errno.ENOSPC;
+    node.key = part;
+    entry.set(node);
+}
+
+pub fn unregister_device(devt: dev_t) void {
+    var dummy_part: core.Partition = undefined;
+    dummy_part.devt = devt;
+    var entry = partitions.getEntryFor(&dummy_part);
+    if (entry.node) |n| {
+        entry.set(null);
+        allocator.destroy(n);
+    }
+}
+
+pub fn init() void {
+    register_block_dev(MAJOR, "blkext") catch unreachable;
+}

--- a/src/block/translator.zig
+++ b/src/block/translator.zig
@@ -1,0 +1,63 @@
+const std = @import("std");
+
+const core = @import("block.zig");
+const STANDARD_BLOCK_SIZE = core.STANDARD_BLOCK_SIZE;
+
+pub const BlockTranslator = @import("translators/base.zig");
+pub const IdentityTranslator = @import("translators/identity.zig");
+pub const ScaledTranslator = @import("translators/scaled.zig");
+
+/// Represents a range of physical blocks
+pub const PhysicalRange = struct {
+    physical_start: u32,
+    physical_count: u32,
+};
+
+/// Translation operation result
+pub const TranslationOp = struct {
+    physical_start: u32,
+    physical_count: u32,
+    buffer_offset: usize,
+    buffer_size: usize,
+    needs_rmw: bool, // Read-modify-write required
+    rmw_offset: usize, // Offset within physical block for partial operations
+    rmw_size: usize, // Size of data to copy for partial operations
+};
+
+pub const VTable = struct {
+    /// Convert logical block address to physical
+    logicalToPhysical: *const fn (ctx: *anyopaque, logical: u32) u32,
+
+    /// Calculate how many physical blocks are needed for logical range
+    calculatePhysicalRange: *const fn (
+        ctx: *anyopaque,
+        logical_start: u32,
+        logical_count: u32,
+    ) PhysicalRange,
+
+    /// Plan translation operations for a logical I/O request
+    planOperations: *const fn (
+        ctx: *anyopaque,
+        logical_start: u32,
+        logical_count: u32,
+        ops: []TranslationOp,
+    ) u32,
+
+    /// Destroy the translator
+    deinit: *const fn (ctx: *anyopaque) void,
+};
+
+/// Create appropriate translator for given block sizes
+pub fn create(allocator: std.mem.Allocator, physical_block_size: u32) !*BlockTranslator {
+    if (physical_block_size == STANDARD_BLOCK_SIZE) {
+        const direct = try IdentityTranslator.create(allocator, physical_block_size);
+        return &direct.base;
+    } else {
+        const scaled = try ScaledTranslator.create(allocator, physical_block_size);
+        return &scaled.base;
+    }
+}
+
+pub fn destroy(translator: *BlockTranslator) void {
+    translator.vtable.deinit(translator.context);
+}

--- a/src/block/translators/base.zig
+++ b/src/block/translators/base.zig
@@ -1,0 +1,182 @@
+const core = @import("../block.zig");
+const STANDARD_BLOCK_SIZE = core.STANDARD_BLOCK_SIZE;
+
+const BlockError = core.BlockError;
+const PhysicalIOFn = core.PhysicalIOFn;
+
+const PhysicalRange = core.translator.PhysicalRange;
+const TranslationOp = core.translator.TranslationOp;
+const VTable = core.translator.VTable;
+
+vtable: *const VTable,
+context: *anyopaque,
+sector_size: u32, // Physical sector size of the underlying device
+block_size: u32, // Logical block size presented to the user (always 512 bytes)
+temp_buffer: ?[]align(16) u8,
+
+// offest and limit will mainly be used for partitioned devices
+logical_offset: u32 = 0, // Offset (in logical blocks) from the start of the device
+logical_limit: ?u32 = null, // logical block limit (null means no limit)
+
+const Self = @This();
+
+/// Read logical blocks using physical I/O
+pub fn read(
+    self: *Self,
+    logical_start: u32,
+    logical_count: u32,
+    buffer: []u8,
+    physical_io: PhysicalIOFn,
+    io_context: *anyopaque,
+) BlockError!void {
+    if (buffer.len < logical_count * self.block_size) {
+        return BlockError.BufferTooSmall;
+    }
+
+    // Check partition limits
+    if (self.logical_limit) |limit| if (logical_start + logical_count > limit)
+        return BlockError.OutOfBounds;
+
+    // Add offset to get absolute address
+    const absolute_start = logical_start + self.logical_offset;
+
+    // For simple 1:1 mapping, use direct path
+    if (self.sector_size == self.block_size) {
+        return physical_io(io_context, absolute_start, logical_count, buffer, .Read);
+    }
+
+    // Complex translation required
+    var ops_buffer: [16]TranslationOp = undefined;
+    const ops_count = self.vtable.planOperations(
+        self.context,
+        absolute_start,
+        logical_count,
+        &ops_buffer,
+    );
+
+    var buffer_offset: usize = 0;
+
+    for (ops_buffer[0..ops_count]) |op| {
+        if (op.needs_rmw) {
+            // Read-modify-write operation for partial blocks
+            try self.performRMWRead(op, buffer, &buffer_offset, physical_io, io_context);
+        } else {
+            // Direct read operation
+            try physical_io(
+                io_context,
+                op.physical_start,
+                op.physical_count,
+                buffer[buffer_offset .. buffer_offset + op.buffer_size],
+                .Read,
+            );
+            buffer_offset += op.buffer_size;
+        }
+    }
+}
+
+/// Write logical blocks using physical I/O
+pub fn write(
+    self: *Self,
+    logical_start: u32,
+    logical_count: u32,
+    buffer: []const u8,
+    physical_io: PhysicalIOFn,
+    io_context: *anyopaque,
+) BlockError!void {
+    if (buffer.len < logical_count * self.block_size) {
+        return BlockError.BufferTooSmall;
+    }
+
+    // Check partition limits
+    if (self.logical_limit) |limit| if (logical_start + logical_count > limit)
+        return BlockError.OutOfBounds;
+
+    // Add offset to get absolute address
+    const absolute_start = logical_start + self.logical_offset;
+
+    // For simple 1:1 mapping, use direct path
+    if (self.sector_size == self.block_size) {
+        const mutable_buffer: []u8 = @constCast(buffer);
+        return physical_io(io_context, absolute_start, logical_count, mutable_buffer, .Write);
+    }
+
+    // Complex translation required
+    var ops_buffer: [16]TranslationOp = undefined;
+    const ops_count = self.vtable.planOperations(
+        self.context,
+        absolute_start,
+        logical_count,
+        &ops_buffer,
+    );
+
+    var buffer_offset: usize = 0;
+
+    for (ops_buffer[0..ops_count]) |op| {
+        if (op.needs_rmw) {
+            // Read-modify-write operation for partial blocks
+            try self.performRMWWrite(op, buffer, &buffer_offset, physical_io, io_context);
+        } else {
+            // Direct write operation
+            const mutable_buffer: []u8 = @constCast(buffer);
+            try physical_io(
+                io_context,
+                op.physical_start,
+                op.physical_count,
+                mutable_buffer[buffer_offset .. buffer_offset + op.buffer_size],
+                .Write,
+            );
+            buffer_offset += op.buffer_size;
+        }
+    }
+}
+
+fn performRMWRead(
+    self: *Self,
+    op: TranslationOp,
+    buffer: []u8,
+    buffer_offset: *usize,
+    physical_io: PhysicalIOFn,
+    io_context: *anyopaque,
+) BlockError!void {
+    const temp_buffer = self.temp_buffer orelse return BlockError.OutOfMemory;
+
+    // Read the physical block
+    try physical_io(io_context, op.physical_start, 1, temp_buffer, .Read);
+
+    // Copy the relevant portion to the output buffer
+    @memcpy(
+        buffer[buffer_offset.* .. buffer_offset.* + op.rmw_size],
+        temp_buffer[op.rmw_offset .. op.rmw_offset + op.rmw_size],
+    );
+
+    buffer_offset.* += op.rmw_size;
+}
+
+fn performRMWWrite(
+    self: *Self,
+    op: TranslationOp,
+    buffer: []const u8,
+    buffer_offset: *usize,
+    physical_io: PhysicalIOFn,
+    io_context: *anyopaque,
+) BlockError!void {
+    const temp_buffer = self.temp_buffer orelse return BlockError.OutOfMemory;
+
+    // Read the existing physical block
+    try physical_io(io_context, op.physical_start, 1, temp_buffer, .Read);
+
+    // Modify the relevant portion
+    @memcpy(
+        temp_buffer[op.rmw_offset .. op.rmw_offset + op.rmw_size],
+        buffer[buffer_offset.* .. buffer_offset.* + op.rmw_size],
+    );
+
+    // Write back the modified block
+    try physical_io(io_context, op.physical_start, 1, temp_buffer, .Write);
+
+    buffer_offset.* += op.rmw_size;
+}
+
+pub fn deinit(self: *Self) void {
+    self.vtable.deinit(self.context);
+}

--- a/src/block/translators/identity.zig
+++ b/src/block/translators/identity.zig
@@ -1,0 +1,82 @@
+const std = @import("std");
+
+const core = @import("../block.zig");
+const STANDARD_BLOCK_SIZE = core.STANDARD_BLOCK_SIZE;
+const BlockError = core.BlockError;
+const BlockTranslator = core.translator.BlockTranslator;
+const PhysicalRange = core.translator.PhysicalRange;
+const TranslationOp = core.translator.TranslationOp;
+const VTable = core.translator.VTable;
+
+const Self = @This();
+
+/// Direct 1:1 translator (logical == physical)
+base: BlockTranslator,
+allocator: std.mem.Allocator,
+
+const vtable = VTable{
+    .logicalToPhysical = logicalToPhysical,
+    .calculatePhysicalRange = calculatePhysicalRange,
+    .planOperations = planOperations,
+    .deinit = destroy,
+};
+
+pub fn create(allocator: std.mem.Allocator, block_size: u32) !*Self {
+    const translator = try allocator.create(Self);
+    translator.* = .{
+        .base = .{
+            .vtable = &vtable,
+            .context = translator,
+            .sector_size = block_size,
+            .block_size = block_size,
+            .temp_buffer = null,
+        },
+        .allocator = allocator,
+    };
+    return translator;
+}
+
+fn logicalToPhysical(ctx: *anyopaque, logical: u32) u32 {
+    _ = ctx;
+    return logical;
+}
+
+fn calculatePhysicalRange(
+    ctx: *anyopaque,
+    logical_start: u32,
+    logical_count: u32,
+) PhysicalRange {
+    _ = ctx;
+    return .{
+        .physical_start = logical_start,
+        .physical_count = logical_count,
+    };
+}
+
+fn planOperations(
+    ctx: *anyopaque,
+    logical_start: u32,
+    logical_count: u32,
+    ops: []TranslationOp,
+) u32 {
+    _ = ctx;
+
+    if (ops.len == 0) return 0;
+
+    ops[0] = .{
+        .physical_start = logical_start,
+        .physical_count = logical_count,
+        .buffer_offset = 0,
+        .buffer_size = logical_count * STANDARD_BLOCK_SIZE,
+        .needs_rmw = false,
+        .rmw_offset = 0,
+        .rmw_size = 0,
+    };
+
+    return 1;
+}
+
+fn destroy(ctx: *anyopaque) void {
+    const self: *Self = @ptrCast(@alignCast(ctx));
+    self.allocator.destroy(self);
+}

--- a/src/block/translators/scaled.zig
+++ b/src/block/translators/scaled.zig
@@ -1,0 +1,204 @@
+const std = @import("std");
+
+const core = @import("../block.zig");
+const STANDARD_BLOCK_SIZE = core.STANDARD_BLOCK_SIZE;
+const BlockError = core.BlockError;
+const BlockTranslator = core.translator.BlockTranslator;
+const PhysicalRange = core.translator.PhysicalRange;
+const TranslationOp = core.translator.TranslationOp;
+const VTable = core.translator.VTable;
+
+const Self = @This();
+
+/// Scaled translator (N logical blocks per physical block)
+base: BlockTranslator,
+allocator: std.mem.Allocator,
+scale_shift: u5, // How many logical blocks per physical (as power of 2)
+block_per_sector: u32,
+
+const vtable = VTable{
+    .logicalToPhysical = logicalToPhysical,
+    .calculatePhysicalRange = calculatePhysicalRange,
+    .planOperations = planOperations,
+    .deinit = destroy,
+};
+
+pub fn create(allocator: std.mem.Allocator, sector_size: u32) !*Self {
+    if (sector_size < STANDARD_BLOCK_SIZE or sector_size % STANDARD_BLOCK_SIZE != 0)
+        return BlockError.InvalidOperation;
+
+    const scale = sector_size / STANDARD_BLOCK_SIZE;
+    const scale_shift: u5 = @intCast(@ctz(scale));
+
+    const translator = try allocator.create(Self);
+    errdefer allocator.destroy(translator);
+
+    const temp_buffer = try allocator.alignedAlloc(u8, .@"16", sector_size);
+    errdefer allocator.free(temp_buffer);
+
+    translator.* = .{
+        .base = .{
+            .vtable = &vtable,
+            .context = translator,
+            .sector_size = sector_size,
+            .block_size = STANDARD_BLOCK_SIZE,
+            .temp_buffer = temp_buffer,
+        },
+        .allocator = allocator,
+        .scale_shift = scale_shift,
+        .block_per_sector = scale,
+    };
+
+    return translator;
+}
+
+fn logicalToPhysical(ctx: *anyopaque, logical: u32) u32 {
+    const self: *Self = @ptrCast(@alignCast(ctx));
+    return logical >> self.scale_shift;
+}
+
+fn calculatePhysicalRange(
+    ctx: *anyopaque,
+    logical_start: u32,
+    logical_count: u32,
+) PhysicalRange {
+    const self: *Self = @ptrCast(@alignCast(ctx));
+
+    const first_physical = logical_start >> self.scale_shift;
+    const last_logical = logical_start + logical_count - 1;
+    const last_physical = last_logical >> self.scale_shift;
+
+    return .{
+        .physical_start = first_physical,
+        .physical_count = @intCast(last_physical - first_physical + 1),
+    };
+}
+
+const PlanState = struct {
+    op_count: u32 = 0,
+    buffer_offset: usize = 0,
+};
+
+fn planFirstBlock(
+    self: *Self,
+    ops: []TranslationOp,
+    state: *PlanState,
+    first_physical: u32,
+    first_offset: usize,
+    last_end: usize,
+    physical_count: u32,
+) bool {
+    const needs_first = first_offset != 0 or (physical_count == 1 and last_end != self.base.sector_size);
+    if (!needs_first) return false;
+
+    if (state.op_count >= ops.len) return true; // signal early exit
+
+    const copy_end = if (physical_count == 1) last_end else self.base.sector_size;
+    const copy_size = copy_end - first_offset;
+
+    ops[state.op_count] = .{
+        .physical_start = first_physical,
+        .physical_count = 1,
+        .buffer_offset = state.buffer_offset,
+        .buffer_size = copy_size,
+        .needs_rmw = true,
+        .rmw_offset = first_offset,
+        .rmw_size = copy_size,
+    };
+
+    state.buffer_offset += copy_size;
+    state.op_count += 1;
+    return physical_count == 1; // true = we're done
+}
+
+fn planMiddleBlocks(
+    self: *Self,
+    ops: []TranslationOp,
+    state: *PlanState,
+    first_physical: u32,
+    first_offset: usize,
+    last_end: usize,
+    physical_count: u32,
+) void {
+    const middle_start = if (first_offset == 0) first_physical else first_physical + 1;
+    const middle_count = if (last_end == self.base.sector_size)
+        physical_count - @intFromBool(first_offset != 0)
+    else
+        physical_count - @intFromBool(first_offset != 0) - 1;
+
+    if (middle_count == 0) return;
+    if (state.op_count >= ops.len) return;
+
+    ops[state.op_count] = .{
+        .physical_start = middle_start,
+        .physical_count = middle_count,
+        .buffer_offset = state.buffer_offset,
+        .buffer_size = middle_count * self.base.sector_size,
+        .needs_rmw = false,
+        .rmw_offset = 0,
+        .rmw_size = 0,
+    };
+
+    state.buffer_offset += middle_count * self.base.sector_size;
+    state.op_count += 1;
+}
+
+fn planLastBlock(
+    self: *Self,
+    ops: []TranslationOp,
+    state: *PlanState,
+    last_physical: u32,
+    last_end: usize,
+    physical_count: u32,
+) void {
+    if (physical_count <= 1 or last_end == self.base.sector_size) return;
+    if (state.op_count >= ops.len) return;
+
+    ops[state.op_count] = .{
+        .physical_start = last_physical,
+        .physical_count = 1,
+        .buffer_offset = state.buffer_offset,
+        .buffer_size = last_end,
+        .needs_rmw = true,
+        .rmw_offset = 0,
+        .rmw_size = last_end,
+    };
+
+    state.op_count += 1;
+}
+
+fn planOperations(
+    ctx: *anyopaque,
+    logical_start: u32,
+    logical_count: u32,
+    ops: []TranslationOp,
+) u32 {
+    const self: *Self = @ptrCast(@alignCast(ctx));
+
+    if (ops.len == 0) return 0;
+
+    const mask = self.block_per_sector - 1;
+    const first_physical = logical_start >> self.scale_shift;
+    const last_logical = logical_start + logical_count - 1;
+    const last_physical = last_logical >> self.scale_shift;
+    const physical_count = last_physical - first_physical + 1;
+
+    const first_offset = (logical_start & mask) * STANDARD_BLOCK_SIZE;
+    const last_end = ((last_logical & mask) + 1) * STANDARD_BLOCK_SIZE;
+
+    var state = PlanState{};
+
+    if (self.planFirstBlock(ops, &state, first_physical, first_offset, last_end, physical_count))
+        return state.op_count;
+
+    self.planMiddleBlocks(ops, &state, first_physical, first_offset, last_end, physical_count);
+    self.planLastBlock(ops, &state, last_physical, last_end, physical_count);
+
+    return state.op_count;
+}
+
+fn destroy(ctx: *anyopaque) void {
+    const self: *Self = @ptrCast(@alignCast(ctx));
+    if (self.base.temp_buffer) |temp_buffer| self.allocator.free(temp_buffer);
+    self.allocator.destroy(self);
+}

--- a/src/boot.zig
+++ b/src/boot.zig
@@ -100,6 +100,9 @@ export fn init(eax: u32, ebx: u32) callconv(.c) void {
     @import("task/ready_queue.zig").init();
     @import("task/wait_queue.zig").init();
 
+    @import("block/registry.zig").init();
+    @import("drivers/block/ramdisk.zig").init();
+
     @import("drivers/pci/pci.zig").init() catch @panic("Failed to initialize PCI subsystem");
 
     const idle_task = @import("task/task_set.zig").create_task() catch @panic("Failed to create idle task");

--- a/src/drivers/block/ramdisk.zig
+++ b/src/drivers/block/ramdisk.zig
@@ -1,0 +1,173 @@
+const std = @import("std");
+
+const memory = @import("../../memory.zig");
+const debug = @import("../../debug.zig");
+
+const blk = @import("../../block/block.zig");
+const STANDARD_BLOCK_SIZE = blk.STANDARD_BLOCK_SIZE;
+const major_t = blk.major_t;
+const minor_t = blk.minor_t;
+const dev_t = blk.dev_t;
+const GenDisk = blk.GenDisk;
+const Partition = blk.Partition;
+const IOType = blk.IOType;
+
+const registry = @import("../../block/registry.zig");
+
+const logger = std.log.scoped(.ramdisk);
+
+const big_allocator = memory.bigAlloc.allocator();
+const small_allocator = memory.smallAlloc.allocator();
+
+const MAJOR: major_t = 1;
+
+// Allow only 1 minor for ramdisk for the main partition.
+// sub-partitions will be assigned to blkext
+const MINORS: minor_t = 1;
+
+const BrdData = struct {
+    storage: []u8,
+};
+
+pub fn create_disk(minor: minor_t, size_mb: u32, sector_size: u32) !*GenDisk {
+    if (sector_size < STANDARD_BLOCK_SIZE or
+        sector_size % STANDARD_BLOCK_SIZE != 0)
+        return blk.BlockError.InvalidOperation;
+
+    const disk = try blk.GenDisk.create(MINORS);
+    errdefer blk.GenDisk.destroy(disk);
+
+    _ = try std.fmt.bufPrint(&disk.name, "ram{}", .{minor});
+
+    const total_size = size_mb * 1024 * 1024;
+
+    const data: *BrdData = try small_allocator.create(BrdData);
+    errdefer small_allocator.destroy(data);
+
+    data.storage = try big_allocator.alloc(u8, total_size);
+    errdefer big_allocator.free(data.storage);
+
+    disk.private_data = @ptrCast(@alignCast(data));
+
+    disk.vtable = &brd_ops;
+    disk.features = .{
+        .readonly = false,
+        .removable = false,
+        .flushable = true,
+        .trimable = true,
+    };
+
+    disk.max_transfer = std.math.maxInt(@TypeOf(disk.max_transfer)); // No practical limit for RAM
+    disk.sector_size = sector_size;
+    disk.major = MAJOR;
+    disk.first_minor = minor;
+
+    _ = disk.add_partition(0, total_size / STANDARD_BLOCK_SIZE) catch |e| {
+        logger.debug("Failed to add whole partition: {s}", .{@errorName(e)});
+        return e;
+    };
+
+    return disk;
+}
+
+const brd_ops = blk.Operations{
+    .physical_io = physical_io,
+    .destroy = destroy,
+};
+
+fn physical_io(
+    context: *anyopaque,
+    sector: u32,
+    count: u32,
+    buffer: []u8,
+    operation: IOType,
+) blk.BlockError!void {
+    const partition: *Partition = @ptrCast(@alignCast(context));
+
+    const sector_size = partition.translator.sector_size;
+    // Calculate the offsets
+    const offset = sector * sector_size;
+    const size = count * sector_size;
+
+    if (partition.disk.private_data == null) return blk.BlockError.IoError;
+
+    const data: *BrdData = @ptrCast(@alignCast(partition.disk.private_data.?));
+
+    // Check the limits
+    if (offset + size > data.storage.len) {
+        return blk.BlockError.OutOfBounds;
+    }
+
+    if (buffer.len != size) {
+        return blk.BlockError.BufferTooSmall;
+    }
+
+    // Perform the operation
+    switch (operation) {
+        .Read => @memcpy(buffer[0..size], data.storage[offset .. offset + size]),
+        .Write => @memcpy(data.storage[offset .. offset + size], buffer[0..size]),
+    }
+}
+
+pub fn destroy(disk: *GenDisk) void {
+    if (disk.private_data == null) return;
+    const data: *BrdData = @ptrCast(@alignCast(disk.private_data));
+    big_allocator.free(data.storage);
+    small_allocator.destroy(data);
+}
+
+pub fn init() void {
+    registry.register_block_dev(MAJOR, "ramdisk") catch {
+        logger.warn("Failed to register ramdisk block device", .{});
+        return;
+    };
+    logger.info("Ramdisk driver initialized", .{});
+
+    // Only run test in debug mode
+    if (std.log.defaultLogEnabled(.debug)) {
+        test_disk();
+    }
+}
+
+pub fn test_disk() void {
+    const disk = create_disk(0, 1, 1024) catch {
+        logger.debug("Failed to create test ramdisk", .{});
+        return;
+    };
+
+    errdefer disk.destroy();
+
+    _ = disk.add_partition(2, 10) catch |e| {
+        logger.debug("Failed to add test partition: {s}", .{@errorName(e)});
+        return;
+    };
+
+    logger.debug("Created test ramdisk: {s} (1MB)", .{disk.name});
+
+    // Simple read/write test
+    var buffer: [512]u8 = undefined;
+    @memset(buffer[0..256], 0x01);
+    @memset(buffer[256..512], 0x02);
+
+    // Write first block of the first partition
+    disk.partition_table.items[1].write(0, 1, &buffer) catch |e| {
+        logger.debug("Test write failed: {s}", .{@errorName(e)});
+        return;
+    };
+
+    // Read it back, from the whole disk (partition 0)
+    @memset(buffer[0..], 0);
+    disk.partition_table.items[0].read(2, 1, &buffer) catch |e| {
+        logger.debug("Test read failed: {s}", .{@errorName(e)});
+        return;
+    };
+
+    const start: usize = @intFromPtr(&buffer);
+    debug.memory_dump(start, start + buffer.len, start);
+
+    if (buffer[0] == 0x01 and buffer[256] == 0x02) {
+        logger.debug("Ramdisk test passed", .{});
+    } else {
+        logger.debug("Ramdisk test failed", .{});
+    }
+}


### PR DESCRIPTION
### Summary

This Pull Request introduces a block device subsystem to handle block device management, along with a simple RAM disk driver and shell commands for block device interaction. It includes various building blocks like block and partition management, device registry, translators, and utility commands for block device operations.

### Key changes:

**New Block Device Subsystem**

  * Implementation of core block device management functionalities via `block.zig`, including structures for device properties, operations, error handling, and statistics.
  * Device translators for physical-to-logical block mapping (including identity and scaled translators).

**Device Registry**

  * Addition of a central registry (`registry.zig`) to manage block devices, partitions, and IDs for mapping and querying.

**Partition Management**

  * Implementation of partition manipulation functionalities in `partition.zig`, enabling partition creation, deletion, and block-level read/write operations.

**Translators**

  * Introduced translators (`translator.zig` & translators) for physical and logical block management, scalable to different sector sizes.

**RAM Disk Driver**

  * Basic in-memory block device driver (`ramdisk.zig`) supporting partitioning, read/write operations, and initialization tests.

**Shell Integrations**

  * New built-in shell commands in `builtins.zig` for:

    * Listing devices and partitions,
    * Performing block-level device reads,
    * Device lookup by name and partition number.

**Integration into Boot**

  * The block subsystem and RAM disk initialization are integrated and invoked during the boot process inside `boot.zig`.

---
Depends-on: #219