### PR TITLE
ADD: IDE HDD block device driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ BOOTLOADER ?= $(shell echo $$(ls ".bootloader-"* 2>/dev/null || echo limine) | c
 OPTIMIZE ?= $(shell echo $$(ls ".optimize-"* 2>/dev/null || echo ReleaseSafe) | cut -d'-' -f2)
 
 BUILD_ARGS ?= --summary all --verbose -Dbootloader=$(BOOTLOADER)
+QEMU_BOOT_DRIVE ?= -hda kfs.iso
+QEMU_DRIVE ?=
 
 .PHONY: all
 all: build
@@ -17,7 +19,8 @@ all: build
 
 .PHONY: run
 run: build
-	qemu-system-i386 -cdrom kfs.iso
+	qemu-system-i386 $(QEMU_BOOT_DRIVE) ${QEMU_DRIVE}
+
 
 .PHONY: build
 build: .optimize-$(OPTIMIZE) .bootloader-$(BOOTLOADER)
@@ -51,7 +54,7 @@ fast: .optimize-ReleaseFast .bootloader-$(BOOTLOADER)
 .PHONY: debug-server
 debug-server: debug
 	pkill -f 'qemu.* -[^ ]*s' || true
-	qemu-system-i386 -cdrom kfs.iso -s -S 1>/dev/null 2>/dev/null &
+	qemu-system-i386 $(QEMU_BOOT_DRIVE) $(QEMU_DRIVE) -s -S 1>/dev/null 2>/dev/null &
 
 .PHONY: clean
 clean:

--- a/src/boot.zig
+++ b/src/boot.zig
@@ -101,9 +101,12 @@ export fn init(eax: u32, ebx: u32) callconv(.c) void {
     @import("task/wait_queue.zig").init();
 
     @import("block/registry.zig").init();
-    @import("drivers/block/ramdisk.zig").init();
 
     @import("drivers/pci/pci.zig").init() catch @panic("Failed to initialize PCI subsystem");
+    @import("drivers/ide/ide.zig").init() catch @panic("Failed to initialize IDE subsystem");
+
+    @import("drivers/block/ramdisk.zig").init();
+    @import("drivers/block/ide_hd.zig").init();
 
     const idle_task = @import("task/task_set.zig").create_task() catch @panic("Failed to create idle task");
 

--- a/src/cpu.zig
+++ b/src/cpu.zig
@@ -332,3 +332,73 @@ pub inline fn save_all_flags() usize {
 pub inline fn restore_all_flags(saved_flags: usize) void {
     write_flags(saved_flags);
 }
+
+/// Read multiple bytes from a port into a u8 slice
+pub fn insb(port: u16, buffer: []u8) void {
+    for (buffer) |*byte| {
+        byte.* = inb(port);
+    }
+}
+
+/// Write multiple bytes to a port from a u8 slice
+pub fn outsb(port: u16, buffer: []const u8) void {
+    for (buffer) |byte| {
+        outb(port, byte);
+    }
+}
+
+/// Read multiple words from a port into a u16 slice
+pub fn insw(port: u16, buffer: []align(1) u16) void {
+    for (buffer) |*word| {
+        word.* = inw(port);
+    }
+}
+
+/// Read multiple words from a port into a u8 slice (must be even length)
+pub fn insw_bytes(port: u16, buffer: []u8) void {
+    std.debug.assert(buffer.len % 2 == 0);
+    const words = std.mem.bytesAsSlice(u16, buffer);
+    insw(port, words);
+}
+
+/// Write multiple words to a port from a u16 slice
+pub fn outsw(port: u16, buffer: []align(1) const u16) void {
+    for (buffer) |word| {
+        outw(port, word);
+    }
+}
+
+/// Write multiple words to a port from a u8 slice (must be even length)
+pub fn outsw_bytes(port: u16, buffer: []const u8) void {
+    std.debug.assert(buffer.len % 2 == 0);
+    const words = std.mem.bytesAsSlice(u16, buffer);
+    outsw(port, words);
+}
+
+/// Read multiple double-words from a port into a u32 slice
+pub fn insl(port: u16, buffer: []align(1) u32) void {
+    for (buffer) |*dword| {
+        dword.* = inl(port);
+    }
+}
+
+/// Read multiple double-words from a port into a u8 slice (must be multiple of 4)
+pub fn insl_bytes(port: u16, buffer: []u8) void {
+    std.debug.assert(buffer.len % 4 == 0);
+    const dwords = std.mem.bytesAsSlice(u32, buffer);
+    insl(port, dwords);
+}
+
+/// Write multiple double-words to a port from a u32 slice
+pub fn outsl(port: u16, buffer: []align(1) const u32) void {
+    for (buffer) |dword| {
+        outl(port, dword);
+    }
+}
+
+/// Write multiple double-words to a port from a u8 slice (must be multiple of 4)
+pub fn outsl_bytes(port: u16, buffer: []const u8) void {
+    std.debug.assert(buffer.len % 4 == 0);
+    const dwords = std.mem.bytesAsSlice(u32, buffer);
+    outsl(port, dwords);
+}

--- a/src/drivers/block/ide_hd.zig
+++ b/src/drivers/block/ide_hd.zig
@@ -58,12 +58,13 @@ const HdData = struct {
 /// - `channel_idx`: Global index of the channel (0 for Primary, 1 for Secondary)
 pub fn create_disk(channel: *Channel, info: DriveInfo, channel_idx: usize) !*GenDisk {
     const disk = try blk.GenDisk.create(MINORS);
+    errdefer disk.destroy();
 
     // Position within the channel (Master=0, Slave=1)
     const pos: u8 = if (info.position == .Master) 0 else 1;
 
     if (channel_idx >= channel_to_major.len) {
-        return error.TooManyChannels;
+        @panic("Too many channels for IDE block driver static configuration");
     }
 
     disk.major = channel_to_major[channel_idx].major;
@@ -78,10 +79,9 @@ pub fn create_disk(channel: *Channel, info: DriveInfo, channel_idx: usize) !*Gen
     // 'a' + (1*2 + 0) = 'c' (hdc) -> Secondary Master
     _ = std.fmt.bufPrint(&disk.name, "hd{c}", .{
         @as(u8, @intCast('a' + (channel_idx * 2 + pos))),
-    }) catch {};
+    }) catch |e| return e;
 
     const data: *HdData = try small_allocator.create(HdData);
-    errdefer small_allocator.destroy(data);
 
     data.drive_info = info;
     data.channel = channel;
@@ -157,6 +157,7 @@ fn probe() u32 {
                                 disk.major,
                                 @errorName(err),
                             });
+                            disk.destroy();
                         }
                     };
                 }
@@ -178,8 +179,6 @@ fn physical_io(
     io_type: blk.IOType,
 ) blk.BlockError!void {
     // Context is the Partition instance calling for IO.
-    // We assert alignment to catch any unsafe pointer casting issues early.
-    std.debug.assert(std.mem.isAligned(@intFromPtr(context), @alignOf(Partition)));
     const partition: *Partition = @ptrCast(@alignCast(context));
 
     if (partition.disk.private_data == null) return blk.BlockError.IoError;
@@ -194,7 +193,7 @@ fn physical_io(
     // Retrieve hardware-specific data (Channel, Position) from Generic Disk private data
     const data: *HdData = @ptrCast(@alignCast(partition.disk.private_data.?));
 
-    const op = ide.IDEOperation{
+    var op = ide.IDEOperation{
         .channel = data.channel,
         .position = data.drive_info.position,
         .lba = sector,

--- a/src/drivers/block/ide_hd.zig
+++ b/src/drivers/block/ide_hd.zig
@@ -1,0 +1,220 @@
+const std = @import("std");
+
+const memory = @import("../../memory.zig");
+const debug = @import("../../debug.zig");
+const ide = @import("../ide/ide.zig");
+
+const log = std.log.scoped(.ide_hd);
+
+const blk = @import("../../block/block.zig");
+const STANDARD_BLOCK_SIZE = blk.STANDARD_BLOCK_SIZE;
+const major_t = blk.major_t;
+const minor_t = blk.minor_t;
+const dev_t = blk.dev_t;
+const GenDisk = blk.GenDisk;
+const Partition = blk.Partition;
+
+const registry = @import("../../block/registry.zig");
+
+// Define Major numbers for standard IDE controllers
+// - Primary Controller (IDE0): Major 3
+// - Secondary Controller (IDE1): Major 22
+// This follows Linux conventions for legacy IDE drivers.
+const Majors = enum(major_t) {
+    IDE0_MAJOR = 3, // Primary channel of first controller
+    IDE1_MAJOR = 22, // Secondary channel of first controller
+    // TODO: Handle more than 2 channels with dynamic major allocation when PCI IDE is implemented
+};
+
+// Map channel index to major/name
+// This static mapping limits us to 2 controllers (4 drives max) which is standard for ISA IDE.
+const channel_to_major = [_]struct { major: major_t, name: []const u8 }{
+    .{ .major = @intFromEnum(Majors.IDE0_MAJOR), .name = "ide0" }, // First controller, Primary
+    .{ .major = @intFromEnum(Majors.IDE1_MAJOR), .name = "ide1" }, // First controller, Secondary
+};
+
+const small_allocator = memory.smallAlloc.allocator();
+
+// Number of minors per IDE channel (e.g., Major 3).
+// We allocate 64 minors to allow for 2 drives of 32 partitions each.
+// - Drive 0 (Master): Minors 0-31
+// - Drive 1 (Slave): Minors 32-63
+const MINORS: minor_t = 64;
+
+const DriveInfo = ide.types.DriveInfo;
+const Channel = ide.Channel;
+
+// Private data attached to the Generic Disk structure.
+// This bridges the Block Device layer (Generic Disk) with the IDE Hardware layer.
+const HdData = struct {
+    drive_info: DriveInfo,
+    channel: *Channel,
+};
+
+/// Create a GenDisk instance for a detected IDE drive.
+///
+/// - `channel`: The hardware channel (Primary/Secondary)
+/// - `info`: Drive information detected during probe (Model, Capacity, etc.)
+/// - `channel_idx`: Global index of the channel (0 for Primary, 1 for Secondary)
+pub fn create_disk(channel: *Channel, info: DriveInfo, channel_idx: usize) !*GenDisk {
+    const disk = try blk.GenDisk.create(MINORS);
+
+    // Position within the channel (Master=0, Slave=1)
+    const pos: u8 = if (info.position == .Master) 0 else 1;
+
+    if (channel_idx >= channel_to_major.len) {
+        return error.TooManyChannels;
+    }
+
+    disk.major = channel_to_major[channel_idx].major;
+
+    // Offset for Slave drive minors.
+    // If Master, starts at 0. If Slave, starts at 32.
+    disk.first_minor = pos * (MINORS / 2);
+
+    // Calculate disk name: hda, hdb for first channel, hdc, hdd for second, etc.
+    // 'a' + (0*2 + 0) = 'a' (hda) -> Primary Master
+    // 'a' + (0*2 + 1) = 'b' (hdb) -> Primary Slave
+    // 'a' + (1*2 + 0) = 'c' (hdc) -> Secondary Master
+    _ = std.fmt.bufPrint(&disk.name, "hd{c}", .{
+        @as(u8, @intCast('a' + (channel_idx * 2 + pos))),
+    }) catch {};
+
+    const data: *HdData = try small_allocator.create(HdData);
+    errdefer small_allocator.destroy(data);
+
+    data.drive_info = info;
+    data.channel = channel;
+
+    disk.private_data = @ptrCast(@alignCast(data));
+
+    disk.vtable = &hd_ops;
+    disk.features = .{
+        .readonly = false,
+        .removable = info.removable,
+        .flushable = true,
+        .trimable = false,
+    };
+
+    disk.max_transfer = 256; // 256 sectors max per operation (Standard ATA limit for LBA28/48 usually chunked)
+    disk.sector_size = info.capacity.sector_size;
+
+    // Register the whole disk partition covering all sectors
+    _ = disk.add_partition(0, info.capacity.sectors) catch |e| {
+        log.debug("Failed to add whole partition: {s}", .{@errorName(e)});
+        return e;
+    };
+
+    return disk;
+}
+
+pub fn destroy(disk: *GenDisk) void {
+    if (disk.private_data == null) return;
+    small_allocator.destroy(disk.private_data.?);
+}
+
+const hd_ops = blk.Operations{
+    .physical_io = physical_io,
+    .destroy = destroy,
+};
+
+/// Probes all IDE channels for connected drives.
+/// Registers them as Block Devices using the `probe` -> `create_disk` -> `register` flow.
+fn probe() u32 {
+    var count: u32 = 0;
+    for (ide.channels) |*channel| {
+        for ([_]ide.Channel.DrivePosition{ .Master, .Slave }) |position| {
+            // Attempt to detect a drive on this channel/position pair
+            if (ide.ata.detectDrive(channel, position)) |info| {
+                const model: []const u8 = std.mem.sliceTo(&info.model, 0);
+
+                log.debug("Drive detected on channel {s} (IDE{d}), position {s}: {s}, {d} sectors", .{
+                    @tagName(channel.channel_type),
+                    channel.interface.index,
+                    @tagName(position),
+                    model,
+                    info.capacity.sectors,
+                });
+
+                // Calculate global channel index for registry mapping
+                const controller_idx = channel.interface.index;
+                const channel_offset: u8 = if (info.channel == .Primary) 0 else 1;
+                const channel_idx = controller_idx * 2 + channel_offset;
+
+                const disk = create_disk(channel, info, channel_idx) catch |err| {
+                    log.err("Failed to create disk for drive {s}: {s}", .{ model, @errorName(err) });
+                    continue;
+                };
+
+                if (channel_idx < channel_to_major.len) {
+                    const name = channel_to_major[channel_idx].name;
+                    // Register the Major number.
+                    // Note: We ignore EBUSY because the first drive (Master) registers the Major.
+                    // The second drive (Slave) shares the SAME Major, so registration will fail with EBUSY.
+                    registry.register_block_dev(disk.major, name) catch |err| {
+                        if (err != error.EBUSY) {
+                            log.err("Failed to register block device major {d}: {s}", .{
+                                disk.major,
+                                @errorName(err),
+                            });
+                        }
+                    };
+                }
+
+                count += 1;
+            }
+        }
+    }
+    return count;
+}
+
+/// Physical I/O entry point called by the Block Layer.
+/// Translates Block Layer requests (Sector/Count) into IDE ATA Commands.
+fn physical_io(
+    context: *anyopaque,
+    sector: u32,
+    count: u32,
+    buffer: []u8,
+    io_type: blk.IOType,
+) blk.BlockError!void {
+    // Context is the Partition instance calling for IO.
+    // We assert alignment to catch any unsafe pointer casting issues early.
+    std.debug.assert(std.mem.isAligned(@intFromPtr(context), @alignOf(Partition)));
+    const partition: *Partition = @ptrCast(@alignCast(context));
+
+    if (partition.disk.private_data == null) return blk.BlockError.IoError;
+
+    const sector_size = partition.translator.sector_size;
+    const expected_size = count * sector_size;
+
+    if (buffer.len < expected_size) {
+        return blk.BlockError.BufferTooSmall;
+    }
+
+    // Retrieve hardware-specific data (Channel, Position) from Generic Disk private data
+    const data: *HdData = @ptrCast(@alignCast(partition.disk.private_data.?));
+
+    const op = ide.IDEOperation{
+        .channel = data.channel,
+        .position = data.drive_info.position,
+        .lba = sector,
+        .count = count,
+        .buffer = switch (io_type) {
+            .Read => .{ .read = buffer },
+            .Write => .{ .write = buffer },
+        },
+        .io_type = io_type,
+    };
+
+    // Delegate the actual hardware I/O to the ATA protocol implementation
+    ide.performOperation(.ATA, &op) catch |err| {
+        return switch (err) {
+            ide.IDEError.OutOfBounds => blk.BlockError.OutOfBounds,
+            else => blk.BlockError.IoError,
+        };
+    };
+}
+
+pub fn init() void {
+    std.log.debug("probe: {d}", .{probe()});
+}

--- a/src/drivers/ide/ata.zig
+++ b/src/drivers/ide/ata.zig
@@ -14,11 +14,19 @@ const Capacity = types.Capacity;
 
 const logger = std.log.scoped(.ATA);
 
+// ATA controllers have a maximum number of sectors per command:
+//   - LBA28: max 256 sectors
+//   - LBA48: max 65536 sectors
+//
+// To transfer more sectors than the limit, we split the operation into "chunks".
+
+/// Returns how many ATA commands are needed.
 fn getTotalChunks(count: u32) usize {
     const max_chunk_size: u16 = 255;
     return (count + max_chunk_size - 1) / max_chunk_size;
 }
 
+/// Returns the LBA and sector count for a specific chunk.
 fn getChunkInfo(total_count: u32, chunk_index: usize) struct { count: u8, offset_sectors: u32 } {
     const max_chunk_size: u32 = 255;
 
@@ -33,7 +41,7 @@ fn getChunkInfo(total_count: u32, chunk_index: usize) struct { count: u8, offset
     const chunk_size = @min(remaining, max_chunk_size);
 
     return .{
-        .count = @as(u8, @truncate(chunk_size)),
+        .count = @intCast(chunk_size),
         .offset_sectors = offset_sectors,
     };
 }
@@ -52,7 +60,7 @@ pub fn performPolling(op: *IDEOperation) IDEError!void {
 
         // Calculate the actual LBA for this specific chunk
         const chunk_lba = op.lba + chunk_info.offset_sectors;
-        const lba32 = @as(u32, @truncate(chunk_lba));
+        const lba32: u32 = @intCast(chunk_lba);
 
         // 1. Select the specific drive (Master/Slave) and set the top 4 bits of LBA
         common.selectLBADevice(.ATA, op);
@@ -104,34 +112,16 @@ pub fn performPolling(op: *IDEOperation) IDEError!void {
 /// This function extracts the drive model and total capacity from the data block returned by the drive.
 fn parseIdentifyData(channel: *const Channel, position: Channel.DrivePosition) DriveInfo {
     var raw: [256]u16 = undefined;
-    // Read 256 words (512 bytes) from the Data Register
-    for (0..256) |i| {
-        raw[i] = cpu.inw(channel.base + constants.ATA.REG_DATA);
-    }
+    cpu.insw(channel.base + constants.ATA.REG_DATA, &raw);
 
     // Read status to clear any pending flags
     _ = cpu.inb(channel.base + constants.ATA.REG_STATUS);
 
-    // Extract model string (Words 27-46)
-    // The string is stored as a sequence of 16-bit words.
-    // KEY DETAIL: Each word contains two ASCII characters, but they are SWAPPED (Big Endian in a Little Endian world).
-    // Example: "QM" is stored as 0x4D51 ('M' << 8 | 'Q'). We must unswap them.
-    var model_arr: [41]u8 = .{0} ** 41;
-    var widx: usize = 27;
-    var midx: usize = 0;
-    while (widx <= 46) : (widx += 1) {
-        const w = raw[widx];
-        model_arr[midx] = @truncate(w >> 8); // High byte is the first character
-        model_arr[midx + 1] = @truncate(w & 0xFF); // Low byte is the second character
-        midx += 2;
-    }
-
-    // Trim trailing spaces to get a clean model name
-    var model_len: usize = 40;
-    while (model_len > 0) : (model_len -= 1) {
-        if (model_arr[model_len - 1] != ' ' and model_arr[model_len - 1] != 0) break;
-    }
-    if (model_len < model_arr.len) model_arr[model_len] = 0;
+    // Extract model string (Words 27-46 of REG_DATA response)
+    std.mem.byteSwapAllFields([20]u16, raw[27..47]);
+    var model: [40]u8 = .{0} ** 40;
+    const trimmed = std.mem.trim(u8, std.mem.asBytes(raw[27..47]), " \x00");
+    @memcpy(model[0..trimmed.len], trimmed);
 
     // Extract total sectors (Words 60-61 for LBA28)
     // Word 60: Low 16 bits of LBA count
@@ -140,12 +130,12 @@ fn parseIdentifyData(channel: *const Channel, position: Channel.DrivePosition) D
     // This driver currently assumes LBA28 capacity for simplicity (max 128GB support).
     const sec_lo: u32 = raw[60];
     const sec_hi: u32 = raw[61];
-    const total: u32 = (@as(u32, sec_hi) << 16) | sec_lo;
+    const total: u32 = (sec_hi << 16) | sec_lo;
 
     logger.debug("identified {s} {s}: {s} ({} sectors)", .{
         @tagName(channel.channel_type),
         @tagName(position),
-        model_arr[0..model_len],
+        model,
         total,
     });
 
@@ -153,7 +143,7 @@ fn parseIdentifyData(channel: *const Channel, position: Channel.DrivePosition) D
         .drive_type = .ATA,
         .channel = channel.channel_type,
         .position = position,
-        .model = model_arr,
+        .model = model,
         .capacity = Capacity{ .sectors = total, .sector_size = 512 },
         .removable = false,
     };
@@ -163,7 +153,7 @@ fn parseIdentifyData(channel: *const Channel, position: Channel.DrivePosition) D
 /// Sequence: SELECT -> RESET STATUS -> SEND IDENTIFY -> WAIT -> READ DATA
 pub fn detectDrive(channel: *const Channel, position: Channel.DrivePosition) ?DriveInfo {
     // 1. Select drive (0xA0 for Master, 0xB0 for Slave)
-    const select: u8 = if (position == .Master) 0xA0 else 0xB0;
+    const select: u8 = if (position == .Master) constants.ATA.SELECT_MASTER else constants.ATA.SELECT_SLAVE;
     cpu.outb(channel.base + constants.ATA.REG_DEVICE, select);
     cpu.io_wait();
 
@@ -177,15 +167,15 @@ pub fn detectDrive(channel: *const Channel, position: Channel.DrivePosition) ?Dr
 
     // 4. Check if a drive exists
     // If Status is 0, no drive is present.
-    var status = cpu.inb(channel.base + constants.ATA.REG_STATUS);
+    const status = cpu.inb(channel.base + constants.ATA.REG_STATUS);
     if (status == 0 or status == 0xFF) {
         return null;
     }
 
     // 5. Wait for the data to be ready (DRQ set, BUSY clear)
-    status = common.waitForData(channel.base, 1000) catch return null;
+    const wait_status = common.waitForData(channel.base, 1000) catch return null;
 
-    if (status & constants.ATA.STATUS_ERROR != 0) {
+    if (wait_status.err) {
         return null;
     }
 

--- a/src/drivers/ide/ata.zig
+++ b/src/drivers/ide/ata.zig
@@ -1,0 +1,194 @@
+const std = @import("std");
+const cpu = @import("../../cpu.zig");
+const ide = @import("ide.zig");
+const timer = @import("../../timer.zig");
+const constants = @import("constants.zig");
+const types = @import("types.zig");
+const common = @import("common.zig");
+const Channel = @import("channel.zig");
+
+const IDEOperation = ide.IDEOperation;
+const DriveInfo = types.DriveInfo;
+const IDEError = types.IDEError;
+const Capacity = types.Capacity;
+
+const logger = std.log.scoped(.ATA);
+
+fn getTotalChunks(count: u32) usize {
+    const max_chunk_size: u16 = 255;
+    return (count + max_chunk_size - 1) / max_chunk_size;
+}
+
+fn getChunkInfo(total_count: u32, chunk_index: usize) struct { count: u8, offset_sectors: u32 } {
+    const max_chunk_size: u32 = 255;
+
+    // Calcul direct de l'offset
+    const offset_sectors = chunk_index * max_chunk_size;
+
+    if (offset_sectors >= total_count) {
+        return .{ .count = 0, .offset_sectors = 0 };
+    }
+
+    const remaining = total_count - offset_sectors;
+    const chunk_size = @min(remaining, max_chunk_size);
+
+    return .{
+        .count = @as(u8, @truncate(chunk_size)),
+        .offset_sectors = offset_sectors,
+    };
+}
+
+pub fn performPolling(op: *IDEOperation) IDEError!void {
+    if (op.lba > 0xFFFFFFF) return IDEError.OutOfBounds;
+
+    // ATA PIO (Programmed I/O) has a limitation: the Sector Count register is 8-bit.
+    // This means we can maximally transfer 255 sectors (or 256 if 0 is interpreted as 256) per command.
+    // To handle larger requests (e.g. 1MB read), we must split the operation into "chunks".
+    const total_chunks = getTotalChunks(op.count);
+
+    for (0..total_chunks) |chunk_idx| {
+        const chunk_info = getChunkInfo(op.count, chunk_idx);
+        if (chunk_info.count == 0) break;
+
+        // Calculate the actual LBA for this specific chunk
+        const chunk_lba = op.lba + chunk_info.offset_sectors;
+        const lba32 = @as(u32, @truncate(chunk_lba));
+
+        // 1. Select the specific drive (Master/Slave) and set the top 4 bits of LBA
+        common.selectLBADevice(.ATA, op);
+
+        // 2. Wait for the BUSY bit to clear before sending command parameters
+        _ = try common.waitForReady(op.channel.base, 1000);
+
+        // 3. Write command parameters to IO ports
+        // sector_count: number of sectors to read/write for this chunk
+        cpu.outb(op.channel.base + constants.ATA.REG_SEC_COUNT, chunk_info.count);
+        // LBA Low/Mid/High: The lower 24 bits of the LBA address
+        cpu.outb(op.channel.base + constants.ATA.REG_LBA_LOW, @truncate(lba32));
+        cpu.outb(op.channel.base + constants.ATA.REG_LBA_MID, @truncate(lba32 >> 8));
+        cpu.outb(op.channel.base + constants.ATA.REG_LBA_HIGH, @truncate(lba32 >> 16));
+
+        const cmd = switch (op.io_type) {
+            .Read => constants.ATA.CMD_READ_SECTORS,
+            .Write => constants.ATA.CMD_WRITE_SECTORS,
+        };
+        // 4. Send the Command (starts the operation on the drive)
+        cpu.outb(op.channel.base + constants.ATA.REG_COMMAND, cmd);
+
+        // 5. Transfer data loop
+        // For each sector in this chunk, we must wait for the drive to be ready (DRQ bit set)
+        // and then transfer 512 bytes (256 words) via the Data Port.
+        for (0..chunk_info.count) |i| {
+            // Wait until drive requests data transfer (Data Request - DRQ)
+            _ = try common.waitForData(op.channel.base, 5000);
+
+            const buffer_offset = (chunk_info.offset_sectors + i) * 512;
+
+            // PIO Data Register (0x1F0/0x170) is 16-bit wide.
+            // We use helper functions to read/write 256 words (512 bytes) efficiently.
+            if (op.io_type == .Write) {
+                common.writeSectorPIO(op.channel.base, op.buffer.write[buffer_offset .. buffer_offset + 512]);
+            } else {
+                common.readSectorPIO(op.channel.base, op.buffer.read[buffer_offset .. buffer_offset + 512]);
+            }
+        }
+
+        // 6. For Write operations, ensure the drive has finished writing the last sector
+        if (op.io_type == .Write) {
+            _ = try common.waitForReady(op.channel.base, 1000);
+        }
+    }
+}
+
+/// Parse ATA IDENTIFY response (512 bytes of information)
+/// This function extracts the drive model and total capacity from the data block returned by the drive.
+fn parseIdentifyData(channel: *const Channel, position: Channel.DrivePosition) DriveInfo {
+    var raw: [256]u16 = undefined;
+    // Read 256 words (512 bytes) from the Data Register
+    for (0..256) |i| {
+        raw[i] = cpu.inw(channel.base + constants.ATA.REG_DATA);
+    }
+
+    // Read status to clear any pending flags
+    _ = cpu.inb(channel.base + constants.ATA.REG_STATUS);
+
+    // Extract model string (Words 27-46)
+    // The string is stored as a sequence of 16-bit words.
+    // KEY DETAIL: Each word contains two ASCII characters, but they are SWAPPED (Big Endian in a Little Endian world).
+    // Example: "QM" is stored as 0x4D51 ('M' << 8 | 'Q'). We must unswap them.
+    var model_arr: [41]u8 = .{0} ** 41;
+    var widx: usize = 27;
+    var midx: usize = 0;
+    while (widx <= 46) : (widx += 1) {
+        const w = raw[widx];
+        model_arr[midx] = @truncate(w >> 8); // High byte is the first character
+        model_arr[midx + 1] = @truncate(w & 0xFF); // Low byte is the second character
+        midx += 2;
+    }
+
+    // Trim trailing spaces to get a clean model name
+    var model_len: usize = 40;
+    while (model_len > 0) : (model_len -= 1) {
+        if (model_arr[model_len - 1] != ' ' and model_arr[model_len - 1] != 0) break;
+    }
+    if (model_len < model_arr.len) model_arr[model_len] = 0;
+
+    // Extract total sectors (Words 60-61 for LBA28)
+    // Word 60: Low 16 bits of LBA count
+    // Word 61: High 16 bits of LBA count
+    // Note: For drives > 128GB (LBA48), we should look at words 100-103.
+    // This driver currently assumes LBA28 capacity for simplicity (max 128GB support).
+    const sec_lo: u32 = raw[60];
+    const sec_hi: u32 = raw[61];
+    const total: u32 = (@as(u32, sec_hi) << 16) | sec_lo;
+
+    logger.debug("identified {s} {s}: {s} ({} sectors)", .{
+        @tagName(channel.channel_type),
+        @tagName(position),
+        model_arr[0..model_len],
+        total,
+    });
+
+    return DriveInfo{
+        .drive_type = .ATA,
+        .channel = channel.channel_type,
+        .position = position,
+        .model = model_arr,
+        .capacity = Capacity{ .sectors = total, .sector_size = 512 },
+        .removable = false,
+    };
+}
+
+/// Detect ATA drive presence and identify it.
+/// Sequence: SELECT -> RESET STATUS -> SEND IDENTIFY -> WAIT -> READ DATA
+pub fn detectDrive(channel: *const Channel, position: Channel.DrivePosition) ?DriveInfo {
+    // 1. Select drive (0xA0 for Master, 0xB0 for Slave)
+    const select: u8 = if (position == .Master) 0xA0 else 0xB0;
+    cpu.outb(channel.base + constants.ATA.REG_DEVICE, select);
+    cpu.io_wait();
+
+    // 2. Clear status by reading it (dummy read)
+    _ = cpu.inb(channel.base + constants.ATA.REG_STATUS);
+
+    // 3. Send IDENTIFY command (0xEC)
+    // This asks the drive to return a 512-byte block describing its features.
+    cpu.outb(channel.base + constants.ATA.REG_COMMAND, constants.ATA.CMD_IDENTIFY);
+    cpu.io_wait();
+
+    // 4. Check if a drive exists
+    // If Status is 0, no drive is present.
+    var status = cpu.inb(channel.base + constants.ATA.REG_STATUS);
+    if (status == 0 or status == 0xFF) {
+        return null;
+    }
+
+    // 5. Wait for the data to be ready (DRQ set, BUSY clear)
+    status = common.waitForData(channel.base, 1000) catch return null;
+
+    if (status & constants.ATA.STATUS_ERROR != 0) {
+        return null;
+    }
+
+    // 6. Read and Parse the IDENTIFY data
+    return parseIdentifyData(channel, position);
+}

--- a/src/drivers/ide/ata.zig
+++ b/src/drivers/ide/ata.zig
@@ -152,9 +152,9 @@ fn parseIdentifyData(channel: *const Channel, position: Channel.DrivePosition) D
 /// Detect ATA drive presence and identify it.
 /// Sequence: SELECT -> RESET STATUS -> SEND IDENTIFY -> WAIT -> READ DATA
 pub fn detectDrive(channel: *const Channel, position: Channel.DrivePosition) ?DriveInfo {
-    // 1. Select drive (0xA0 for Master, 0xB0 for Slave)
-    const select: u8 = if (position == .Master) constants.ATA.SELECT_MASTER else constants.ATA.SELECT_SLAVE;
-    cpu.outb(channel.base + constants.ATA.REG_DEVICE, select);
+    // 1. Select drive
+    cpu.outb(channel.base + constants.ATA.REG_DEVICE, @bitCast(types.DeviceRegister.select(position)));
+
     cpu.io_wait();
 
     // 2. Clear status by reading it (dummy read)

--- a/src/drivers/ide/ata.zig
+++ b/src/drivers/ide/ata.zig
@@ -63,7 +63,7 @@ pub fn performPolling(op: *IDEOperation) IDEError!void {
         const lba32: u32 = @intCast(chunk_lba);
 
         // 1. Select the specific drive (Master/Slave) and set the top 4 bits of LBA
-        common.selectLBADevice(.ATA, op);
+        common.selectDevice(op.channel.base, types.DeviceRegister.ataLBA28(op.position, op.lba));
 
         // 2. Wait for the BUSY bit to clear before sending command parameters
         _ = try common.waitForReady(op.channel.base, 1000);
@@ -153,7 +153,7 @@ fn parseIdentifyData(channel: *const Channel, position: Channel.DrivePosition) D
 /// Sequence: SELECT -> RESET STATUS -> SEND IDENTIFY -> WAIT -> READ DATA
 pub fn detectDrive(channel: *const Channel, position: Channel.DrivePosition) ?DriveInfo {
     // 1. Select drive
-    cpu.outb(channel.base + constants.ATA.REG_DEVICE, @bitCast(types.DeviceRegister.select(position)));
+    common.selectDevice(channel.base, types.DeviceRegister.select(position));
 
     cpu.io_wait();
 

--- a/src/drivers/ide/atapi.zig
+++ b/src/drivers/ide/atapi.zig
@@ -43,8 +43,7 @@ fn issueRead10(
     const base = channel.base;
 
     // 1. Select the ATAPI device
-    cpu.outb(base + constants.ATA.REG_DEVICE, @bitCast(types.DeviceRegister.select(position)));
-    cpu.io_wait();
+    common.selectDevice(base, types.DeviceRegister.select(position));
 
     // 2. Wait for drive readiness
     _ = try common.waitForReady(base, 1000);
@@ -104,8 +103,7 @@ fn issueRead10(
 
 /// Get ATAPI drive capacity (improved version)
 fn getCapacity(channel: *const Channel, position: Channel.DrivePosition) !Capacity {
-    cpu.outb(channel.base + constants.ATA.REG_DEVICE, @bitCast(types.DeviceRegister.select(position)));
-    cpu.io_wait();
+    common.selectDevice(channel.base, types.DeviceRegister.select(position));
 
     _ = try common.waitForReady(channel.base, 1000);
 
@@ -191,8 +189,7 @@ fn parseIdentifyData(channel: *const Channel, position: Channel.DrivePosition) D
 /// Instead, we must check for a specific "Signature" in the Cylinder/LBA registers after a soft reset.
 pub fn detectDrive(channel: *const Channel, position: Channel.DrivePosition) ?DriveInfo {
     // 1. Select drive
-    cpu.outb(channel.base + constants.ATA.REG_DEVICE, @bitCast(types.DeviceRegister.select(position)));
-    cpu.io_wait();
+    common.selectDevice(channel.base, types.DeviceRegister.select(position));
 
     // 2. Send Software Reset (bit 2 of Control Register)
     // This resets the drive logic but keeps the configuration.

--- a/src/drivers/ide/atapi.zig
+++ b/src/drivers/ide/atapi.zig
@@ -13,71 +13,89 @@ const Capacity = types.Capacity;
 
 const logger = std.log.scoped(.ATAPI);
 
+const max_transfer_sectors = std.math.maxInt(u16);
+
 pub fn performPolling(op: *@import("ide.zig").IDEOperation) types.IDEError!void {
-    // 1. Select the ATAPI device (similar to ATA but with different flags)
-    common.selectLBADevice(.ATAPI, op);
+    const sector_size: u32 = 2048;
+    var remaining: u32 = op.count;
+    var lba: u32 = op.lba;
+    var buffer_offset: usize = 0;
+
+    while (remaining > 0) {
+        const chunk: u16 = @intCast(@min(remaining, max_transfer_sectors));
+        const chunk_bytes = @as(usize, chunk) * sector_size;
+
+        try issueRead10(op.channel, op.position, lba, chunk, op.buffer.read[buffer_offset..][0..chunk_bytes]);
+
+        remaining -= chunk;
+        lba += chunk;
+        buffer_offset += chunk_bytes;
+    }
+}
+
+fn issueRead10(
+    channel: *const Channel,
+    position: Channel.DrivePosition,
+    lba: u32,
+    count: u16,
+    buffer: []u8,
+) IDEError!void {
+    const base = channel.base;
+
+    // 1. Select the ATAPI device
+    cpu.outb(base + constants.ATA.REG_DEVICE, @bitCast(types.DeviceRegister.select(position)));
+    cpu.io_wait();
 
     // 2. Wait for drive readiness
-    _ = try common.waitForReady(op.channel.base, 1000);
+    _ = try common.waitForReady(base, 1000);
 
-    // 3. Prepare for PACKET command
-    // ATAPI uses the host's capabilities. We set features to 0 (no DMA, PIO mode).
-    // Specifically for ATAPI, LBA Mid/High registers specify the maximum byte count allowed for the transfer.
-    // Here we set it to max (0xFFFE/0xFFFF) to avoid truncation.
-    cpu.outb(op.channel.base + constants.ATA.REG_FEATURES, 0x00);
-    cpu.outb(op.channel.base + constants.ATA.REG_LBA_MID, 0xFE);
-    cpu.outb(op.channel.base + constants.ATA.REG_LBA_HIGH, 0xFF);
+    // 3. Prepare for PACKET command (PIO mode, max byte count)
+    cpu.outb(base + constants.ATA.REG_FEATURES, 0x00);
+    cpu.outb(base + constants.ATA.REG_LBA_MID, 0xFE);
+    cpu.outb(base + constants.ATA.REG_LBA_HIGH, 0xFF);
 
-    // 4. Send the PACKET command (0xA0)
-    // This tells the drive "I'm about to send you a SCSI-like command packet structure"
-    cpu.outb(op.channel.base + constants.ATA.REG_COMMAND, constants.ATA.CMD_PACKET);
+    // 4. Send the PACKET command
+    cpu.outb(base + constants.ATA.REG_COMMAND, constants.ATA.CMD_PACKET);
 
     // 5. Wait for the drive to accept the packet (DRQ set)
-    _ = try common.waitForData(op.channel.base, 1000);
+    _ = try common.waitForData(base, 1000);
 
-    // 6. Send the SCSI Command Packet (12 bytes)
-    // We construct a SCSI READ(10) command manually.
+    // 6. Send the SCSI READ(10) Command Packet (12 bytes)
     var packet = std.mem.zeroes(constants.SCSI.Read10);
     packet.opcode = constants.ATAPI.CMD_READ10;
-    packet.lba = std.mem.nativeToBig(u32, @intCast(op.lba));
-    packet.transfer_len = std.mem.nativeToBig(u16, @intCast(op.count));
+    packet.lba = std.mem.nativeToBig(u32, lba);
+    packet.transfer_len = std.mem.nativeToBig(u16, count);
 
-    // Send the 12 bytes of the packet as 6 words (16-bit writes)
     const packet_bytes = std.mem.asBytes(&packet);
-    cpu.outsw_bytes(op.channel.base + constants.ATA.REG_DATA, packet_bytes);
+    cpu.outsw_bytes(base + constants.ATA.REG_DATA, packet_bytes);
 
     // 7. Data Transfer Phase
     var bytes_read: usize = 0;
-    const expected_bytes = @as(usize, op.count) * 2048; // CD-ROM sectors are typically 2048 bytes
+    const expected_bytes: usize = @as(usize, count) * 2048;
 
     while (bytes_read < expected_bytes) {
-        // Wait for IRQ or polling status. DRQ indicates data is ready to be read.
-        // If BUSY clears and DRQ is missing, the transfer is over.
-        const status = try common.waitForDataOrCompletion(op.channel.base, 5000);
+        const status = try common.waitForDataOrCompletion(base, 5000);
         if (!status.drq) break;
 
-        // Read the actual size of the data chunk available from LBA Mid/High registers
-        const byte_count_low = cpu.inb(op.channel.base + constants.ATA.REG_LBA_MID);
-        const byte_count_high = cpu.inb(op.channel.base + constants.ATA.REG_LBA_HIGH);
+        const byte_count_low = cpu.inb(base + constants.ATA.REG_LBA_MID);
+        const byte_count_high = cpu.inb(base + constants.ATA.REG_LBA_HIGH);
         const byte_count = (@as(u16, byte_count_high) << 8) | byte_count_low;
 
         if (byte_count == 0) break;
 
-        // Sanity check preventing buffer overflow
         const bytes_to_read = @min(byte_count, expected_bytes - bytes_read);
 
-        // Read the chunk data
         const full_words = bytes_to_read / 2;
         const has_partial = bytes_to_read % 2 != 0;
 
-        if (bytes_read + full_words * 2 <= op.buffer.read.len) {
-            const data_slice = op.buffer.read[bytes_read..][0 .. full_words * 2];
-            cpu.insw_bytes(op.channel.base + constants.ATA.REG_DATA, data_slice);
+        if (bytes_read + full_words * 2 <= buffer.len) {
+            const data_slice = buffer[bytes_read..][0 .. full_words * 2];
+            cpu.insw_bytes(base + constants.ATA.REG_DATA, data_slice);
         }
 
-        if (has_partial and bytes_read + full_words * 2 < op.buffer.read.len) {
-            const word = cpu.inw(op.channel.base + constants.ATA.REG_DATA);
-            op.buffer.read[bytes_read + full_words * 2] = @truncate(word);
+        if (has_partial and bytes_read + full_words * 2 < buffer.len) {
+            const word = cpu.inw(base + constants.ATA.REG_DATA);
+            buffer[bytes_read + full_words * 2] = @truncate(word);
         }
 
         bytes_read += bytes_to_read;
@@ -86,8 +104,7 @@ pub fn performPolling(op: *@import("ide.zig").IDEOperation) types.IDEError!void 
 
 /// Get ATAPI drive capacity (improved version)
 fn getCapacity(channel: *const Channel, position: Channel.DrivePosition) !Capacity {
-    const select: u8 = if (position == .Master) constants.ATA.SELECT_MASTER else constants.ATA.SELECT_SLAVE;
-    cpu.outb(channel.base + constants.ATA.REG_DEVICE, select);
+    cpu.outb(channel.base + constants.ATA.REG_DEVICE, @bitCast(types.DeviceRegister.select(position)));
     cpu.io_wait();
 
     _ = try common.waitForReady(channel.base, 1000);
@@ -174,8 +191,7 @@ fn parseIdentifyData(channel: *const Channel, position: Channel.DrivePosition) D
 /// Instead, we must check for a specific "Signature" in the Cylinder/LBA registers after a soft reset.
 pub fn detectDrive(channel: *const Channel, position: Channel.DrivePosition) ?DriveInfo {
     // 1. Select drive
-    const select: u8 = if (position == .Master) constants.ATA.SELECT_MASTER else constants.ATA.SELECT_SLAVE;
-    cpu.outb(channel.base + constants.ATA.REG_DEVICE, select);
+    cpu.outb(channel.base + constants.ATA.REG_DEVICE, @bitCast(types.DeviceRegister.select(position)));
     cpu.io_wait();
 
     // 2. Send Software Reset (bit 2 of Control Register)

--- a/src/drivers/ide/atapi.zig
+++ b/src/drivers/ide/atapi.zig
@@ -1,0 +1,253 @@
+const std = @import("std");
+const cpu = @import("../../cpu.zig");
+const ide = @import("ide.zig");
+const constants = @import("constants.zig");
+const types = @import("types.zig");
+const common = @import("common.zig");
+const Channel = @import("channel.zig");
+
+const IDEOperation = ide.IDEOperation;
+const DriveInfo = types.DriveInfo;
+const IDEError = types.IDEError;
+const Capacity = types.Capacity;
+
+const logger = std.log.scoped(.ATAPI);
+
+pub fn performPolling(op: *@import("ide.zig").IDEOperation) types.IDEError!void {
+    // 1. Select the ATAPI device (similar to ATA but with different flags)
+    common.selectLBADevice(.ATAPI, op);
+
+    // 2. Wait for drive readiness
+    _ = try common.waitForReady(op.channel.base, 1000);
+
+    // 3. Prepare for PACKET command
+    // ATAPI uses the host's capabilities. We set features to 0 (no DMA, PIO mode).
+    // Specifically for ATAPI, LBA Mid/High registers specify the maximum byte count allowed for the transfer.
+    // Here we set it to max (0xFFFE/0xFFFF) to avoid truncation.
+    cpu.outb(op.channel.base + constants.ATA.REG_FEATURES, 0x00);
+    cpu.outb(op.channel.base + constants.ATA.REG_LBA_MID, 0xFE);
+    cpu.outb(op.channel.base + constants.ATA.REG_LBA_HIGH, 0xFF);
+
+    // 4. Send the PACKET command (0xA0)
+    // This tells the drive "I'm about to send you a SCSI-like command packet structure"
+    cpu.outb(op.channel.base + constants.ATA.REG_COMMAND, constants.ATA.CMD_PACKET);
+
+    // 5. Wait for the drive to accept the packet (DRQ set)
+    _ = try common.waitForData(op.channel.base, 1000);
+
+    // 6. Send the SCSI Command Packet (12 bytes)
+    // We construct a SCSI READ(10) command manually.
+    var packet: [12]u8 = .{0} ** 12;
+    packet[0] = constants.ATAPI.CMD_READ10; // Operation Code
+    // LBA (Logical Block Address) - Big Endian for SCSI
+    packet[2] = @truncate(op.lba >> 24);
+    packet[3] = @truncate(op.lba >> 16);
+    packet[4] = @truncate(op.lba >> 8);
+    packet[5] = @truncate(op.lba);
+    // Transfer Length (in blocks) - Big Endian
+    packet[7] = @truncate(op.count >> 8);
+    packet[8] = @truncate(op.count);
+
+    // Send the 12 bytes of the packet as 6 words (16-bit writes)
+    for (0..6) |i| {
+        const low = packet[i * 2];
+        const high = packet[i * 2 + 1];
+        const word: u16 = (@as(u16, high) << 8) | low;
+        cpu.outw(op.channel.base + constants.ATA.REG_DATA, word);
+    }
+
+    // 7. Data Transfer Phase
+    var bytes_read: usize = 0;
+    const expected_bytes = @as(usize, op.count) * 2048; // CD-ROM sectors are typically 2048 bytes
+
+    while (bytes_read < expected_bytes) {
+        // Wait for IRQ or polling status. DRQ indicates data is ready to be read.
+        // If BUSY clears and DRQ is missing, the transfer is over.
+        const status = try common.waitForDataOrCompletion(op.channel.base, 5000);
+        if ((status & constants.ATA.STATUS_DRQ) == 0) break;
+
+        // Read the actual size of the data chunk available from LBA Mid/High registers
+        const byte_count_low = cpu.inb(op.channel.base + constants.ATA.REG_LBA_MID);
+        const byte_count_high = cpu.inb(op.channel.base + constants.ATA.REG_LBA_HIGH);
+        const byte_count = (@as(u16, byte_count_high) << 8) | byte_count_low;
+
+        if (byte_count == 0) break;
+
+        // Sanity check preventing buffer overflow
+        const bytes_to_read = @min(byte_count, expected_bytes - bytes_read);
+        const word_count = (bytes_to_read + 1) / 2;
+
+        // Read the chunk data
+        for (0..word_count) |i| {
+            const word = cpu.inw(op.channel.base + constants.ATA.REG_DATA);
+            const offset = bytes_read + i * 2;
+
+            if (offset < op.buffer.read.len) {
+                op.buffer.read[offset] = @truncate(word);
+            }
+            if (offset + 1 < op.buffer.read.len) {
+                op.buffer.read[offset + 1] = @truncate(word >> 8);
+            }
+        }
+
+        bytes_read += bytes_to_read;
+    }
+}
+
+/// Get ATAPI drive capacity (improved version)
+fn getCapacity(channel: *const Channel, position: Channel.DrivePosition) !Capacity {
+    const select: u8 = if (position == .Master) 0xA0 else 0xB0;
+    cpu.outb(channel.base + constants.ATA.REG_DEVICE, select);
+    cpu.io_wait();
+
+    _ = try common.waitForReady(channel.base, 1000);
+
+    // Configure for PACKET command
+    cpu.outb(channel.base + constants.ATA.REG_FEATURES, 0x00);
+    cpu.outb(channel.base + constants.ATA.REG_LBA_MID, 0x08);
+    cpu.outb(channel.base + constants.ATA.REG_LBA_HIGH, 0x00);
+
+    // Send PACKET command
+    cpu.outb(channel.base + constants.ATA.REG_COMMAND, constants.ATA.CMD_PACKET);
+
+    // Wait for DRQ
+    const status = try common.waitForData(channel.base, 1000);
+    if (status & constants.ATA.STATUS_ERROR != 0) {
+        return IDEError.ReadError;
+    }
+
+    // Send READ CAPACITY packet
+    var packet: [12]u8 = .{0} ** 12;
+    packet[0] = constants.ATAPI.CMD_READ_CAPACITY;
+
+    // Send packet (6 words)
+    for (0..6) |i| {
+        const low = packet[i * 2];
+        const high = if (i * 2 + 1 < packet.len) packet[i * 2 + 1] else 0;
+        const word: u16 = (@as(u16, high) << 8) | low;
+        cpu.outw(channel.base + constants.ATA.REG_DATA, word);
+    }
+
+    // Wait for data
+    _ = try common.waitForData(channel.base, 1000);
+
+    // Read response (8 bytes)
+    var response: [8]u8 = undefined;
+    for (0..4) |i| {
+        const word = cpu.inw(channel.base + constants.ATA.REG_DATA);
+        response[i * 2] = @truncate(word);
+        response[i * 2 + 1] = @truncate(word >> 8);
+    }
+
+    // Parse response
+    const last_lba = (@as(u32, response[0]) << 24) |
+        (@as(u32, response[1]) << 16) |
+        (@as(u32, response[2]) << 8) |
+        response[3];
+
+    const block_size = (@as(u32, response[4]) << 24) |
+        (@as(u32, response[5]) << 16) |
+        (@as(u32, response[6]) << 8) |
+        response[7];
+
+    return Capacity{ .sectors = last_lba + 1, .sector_size = block_size };
+}
+
+/// Parse ATAPI IDENTIFY response
+fn parseIdentifyData(channel: *const Channel, position: Channel.DrivePosition) DriveInfo {
+    var raw: [256]u16 = undefined;
+    for (0..256) |i| {
+        raw[i] = cpu.inw(channel.base + constants.ATA.REG_DATA);
+    }
+
+    _ = cpu.inb(channel.base + constants.ATA.REG_STATUS);
+
+    // Extract model string
+    var model_arr: [41]u8 = .{0} ** 41;
+    var widx: usize = 27;
+    var midx: usize = 0;
+    while (widx <= 46) : (widx += 1) {
+        const w = raw[widx];
+        model_arr[midx] = @truncate(w >> 8);
+        model_arr[midx + 1] = @truncate(w & 0xFF);
+        midx += 2;
+    }
+
+    // Trim trailing spaces
+    var model_len: usize = 40;
+    while (model_len > 0) : (model_len -= 1) {
+        if (model_arr[model_len - 1] != ' ' and model_arr[model_len - 1] != 0) break;
+    }
+    if (model_len < model_arr.len) model_arr[model_len] = 0;
+
+    const removable = (raw[0] & 0x80) != 0;
+
+    logger.debug("identified {s} {s}: {s} (removable: {s})", .{
+        @tagName(channel.channel_type),
+        @tagName(position),
+        model_arr[0..model_len],
+        if (removable) "yes" else "no",
+    });
+
+    // Try to get capacity (may fail if no media)
+    var capacity = Capacity{ .sectors = 0, .sector_size = 2048 };
+    if (getCapacity(channel, position)) |cap| {
+        capacity = cap;
+    } else |err| {
+        logger.debug("Could not read ATAPI capacity: {s} (no media?)", .{@errorName(err)});
+    }
+
+    return DriveInfo{
+        .drive_type = .ATAPI,
+        .channel = channel.channel_type,
+        .position = position,
+        .model = model_arr,
+        .capacity = capacity,
+        .removable = removable,
+    };
+}
+
+/// Detect ATAPI drive
+/// ATAPI drives function differently: they often don't respond to standard ATA IDENTIFY.
+/// Instead, we must check for a specific "Signature" in the Cylinder/LBA registers after a soft reset.
+pub fn detectDrive(channel: *const Channel, position: Channel.DrivePosition) ?DriveInfo {
+    // 1. Select drive
+    const select: u8 = if (position == .Master) 0xA0 else 0xB0;
+    cpu.outb(channel.base + constants.ATA.REG_DEVICE, select);
+    cpu.io_wait();
+
+    // 2. Send Software Reset (bit 2 of Control Register)
+    // This resets the drive logic but keeps the configuration.
+    cpu.outb(channel.ctrl, 0x04);
+    cpu.io_wait();
+    cpu.outb(channel.ctrl, 0x00); // Clear reset
+    cpu.io_wait();
+
+    // 3. Wait until the drive is finished resetting (Ready bit set)
+    _ = common.waitForReady(channel.base, 1000) catch return null;
+
+    // 4. Check ATAPI Signature
+    // After reset, ATAPI drives place specific values in LBA Mid/High registers.
+    // LBA Mid:  0x14
+    // LBA High: 0xEB
+    const lba_mid = cpu.inb(channel.base + constants.ATA.REG_LBA_MID);
+    const lba_high = cpu.inb(channel.base + constants.ATA.REG_LBA_HIGH);
+
+    if (lba_mid == constants.ATAPI.SIGNATURE_MID and lba_high == constants.ATAPI.SIGNATURE_HIGH) {
+        // ATAPI signature found!
+
+        // 5. Send IDENTIFY PACKET DEVICE command (0xA1)
+        // This is the ATAPI equivalent of IDENTIFY.
+        cpu.outb(channel.base + constants.ATA.REG_COMMAND, constants.ATA.CMD_IDENTIFY_PACKET);
+        cpu.io_wait();
+
+        // 6. Wait for data
+        const status = common.waitForData(channel.base, 1000) catch return null;
+        if (status & constants.ATA.STATUS_ERROR != 0) return null;
+
+        // 7. Parse identification data (similar structure to ATA IDENTIFY)
+        return parseIdentifyData(channel, position);
+    }
+
+    return null;
+}

--- a/src/drivers/ide/atapi.zig
+++ b/src/drivers/ide/atapi.zig
@@ -37,24 +37,14 @@ pub fn performPolling(op: *@import("ide.zig").IDEOperation) types.IDEError!void 
 
     // 6. Send the SCSI Command Packet (12 bytes)
     // We construct a SCSI READ(10) command manually.
-    var packet: [12]u8 = .{0} ** 12;
-    packet[0] = constants.ATAPI.CMD_READ10; // Operation Code
-    // LBA (Logical Block Address) - Big Endian for SCSI
-    packet[2] = @truncate(op.lba >> 24);
-    packet[3] = @truncate(op.lba >> 16);
-    packet[4] = @truncate(op.lba >> 8);
-    packet[5] = @truncate(op.lba);
-    // Transfer Length (in blocks) - Big Endian
-    packet[7] = @truncate(op.count >> 8);
-    packet[8] = @truncate(op.count);
+    var packet = std.mem.zeroes(constants.SCSI.Read10);
+    packet.opcode = constants.ATAPI.CMD_READ10;
+    packet.lba = std.mem.nativeToBig(u32, @intCast(op.lba));
+    packet.transfer_len = std.mem.nativeToBig(u16, @intCast(op.count));
 
     // Send the 12 bytes of the packet as 6 words (16-bit writes)
-    for (0..6) |i| {
-        const low = packet[i * 2];
-        const high = packet[i * 2 + 1];
-        const word: u16 = (@as(u16, high) << 8) | low;
-        cpu.outw(op.channel.base + constants.ATA.REG_DATA, word);
-    }
+    const packet_bytes = std.mem.asBytes(&packet);
+    cpu.outsw_bytes(op.channel.base + constants.ATA.REG_DATA, packet_bytes);
 
     // 7. Data Transfer Phase
     var bytes_read: usize = 0;
@@ -64,7 +54,7 @@ pub fn performPolling(op: *@import("ide.zig").IDEOperation) types.IDEError!void 
         // Wait for IRQ or polling status. DRQ indicates data is ready to be read.
         // If BUSY clears and DRQ is missing, the transfer is over.
         const status = try common.waitForDataOrCompletion(op.channel.base, 5000);
-        if ((status & constants.ATA.STATUS_DRQ) == 0) break;
+        if (!status.drq) break;
 
         // Read the actual size of the data chunk available from LBA Mid/High registers
         const byte_count_low = cpu.inb(op.channel.base + constants.ATA.REG_LBA_MID);
@@ -75,19 +65,19 @@ pub fn performPolling(op: *@import("ide.zig").IDEOperation) types.IDEError!void 
 
         // Sanity check preventing buffer overflow
         const bytes_to_read = @min(byte_count, expected_bytes - bytes_read);
-        const word_count = (bytes_to_read + 1) / 2;
 
         // Read the chunk data
-        for (0..word_count) |i| {
-            const word = cpu.inw(op.channel.base + constants.ATA.REG_DATA);
-            const offset = bytes_read + i * 2;
+        const full_words = bytes_to_read / 2;
+        const has_partial = bytes_to_read % 2 != 0;
 
-            if (offset < op.buffer.read.len) {
-                op.buffer.read[offset] = @truncate(word);
-            }
-            if (offset + 1 < op.buffer.read.len) {
-                op.buffer.read[offset + 1] = @truncate(word >> 8);
-            }
+        if (bytes_read + full_words * 2 <= op.buffer.read.len) {
+            const data_slice = op.buffer.read[bytes_read..][0 .. full_words * 2];
+            cpu.insw_bytes(op.channel.base + constants.ATA.REG_DATA, data_slice);
+        }
+
+        if (has_partial and bytes_read + full_words * 2 < op.buffer.read.len) {
+            const word = cpu.inw(op.channel.base + constants.ATA.REG_DATA);
+            op.buffer.read[bytes_read + full_words * 2] = @truncate(word);
         }
 
         bytes_read += bytes_to_read;
@@ -96,7 +86,7 @@ pub fn performPolling(op: *@import("ide.zig").IDEOperation) types.IDEError!void 
 
 /// Get ATAPI drive capacity (improved version)
 fn getCapacity(channel: *const Channel, position: Channel.DrivePosition) !Capacity {
-    const select: u8 = if (position == .Master) 0xA0 else 0xB0;
+    const select: u8 = if (position == .Master) constants.ATA.SELECT_MASTER else constants.ATA.SELECT_SLAVE;
     cpu.outb(channel.base + constants.ATA.REG_DEVICE, select);
     cpu.io_wait();
 
@@ -112,43 +102,29 @@ fn getCapacity(channel: *const Channel, position: Channel.DrivePosition) !Capaci
 
     // Wait for DRQ
     const status = try common.waitForData(channel.base, 1000);
-    if (status & constants.ATA.STATUS_ERROR != 0) {
+    if (status.err) {
         return IDEError.ReadError;
     }
 
     // Send READ CAPACITY packet
-    var packet: [12]u8 = .{0} ** 12;
-    packet[0] = constants.ATAPI.CMD_READ_CAPACITY;
+    var packet = std.mem.zeroes(constants.SCSI.ReadCapacity);
+    packet.opcode = constants.ATAPI.CMD_READ_CAPACITY;
 
     // Send packet (6 words)
-    for (0..6) |i| {
-        const low = packet[i * 2];
-        const high = if (i * 2 + 1 < packet.len) packet[i * 2 + 1] else 0;
-        const word: u16 = (@as(u16, high) << 8) | low;
-        cpu.outw(channel.base + constants.ATA.REG_DATA, word);
-    }
+    const packet_bytes = std.mem.asBytes(&packet);
+    cpu.outsw_bytes(channel.base + constants.ATA.REG_DATA, packet_bytes);
 
     // Wait for data
     _ = try common.waitForData(channel.base, 1000);
 
     // Read response (8 bytes)
     var response: [8]u8 = undefined;
-    for (0..4) |i| {
-        const word = cpu.inw(channel.base + constants.ATA.REG_DATA);
-        response[i * 2] = @truncate(word);
-        response[i * 2 + 1] = @truncate(word >> 8);
-    }
+    cpu.insw_bytes(channel.base + constants.ATA.REG_DATA, &response);
 
     // Parse response
-    const last_lba = (@as(u32, response[0]) << 24) |
-        (@as(u32, response[1]) << 16) |
-        (@as(u32, response[2]) << 8) |
-        response[3];
+    const last_lba = std.mem.readInt(u32, response[0..4], .big);
 
-    const block_size = (@as(u32, response[4]) << 24) |
-        (@as(u32, response[5]) << 16) |
-        (@as(u32, response[6]) << 8) |
-        response[7];
+    const block_size = std.mem.readInt(u32, response[4..8], .big);
 
     return Capacity{ .sectors = last_lba + 1, .sector_size = block_size };
 }
@@ -156,36 +132,22 @@ fn getCapacity(channel: *const Channel, position: Channel.DrivePosition) !Capaci
 /// Parse ATAPI IDENTIFY response
 fn parseIdentifyData(channel: *const Channel, position: Channel.DrivePosition) DriveInfo {
     var raw: [256]u16 = undefined;
-    for (0..256) |i| {
-        raw[i] = cpu.inw(channel.base + constants.ATA.REG_DATA);
-    }
+    cpu.insw(channel.base + constants.ATA.REG_DATA, &raw);
 
     _ = cpu.inb(channel.base + constants.ATA.REG_STATUS);
 
-    // Extract model string
-    var model_arr: [41]u8 = .{0} ** 41;
-    var widx: usize = 27;
-    var midx: usize = 0;
-    while (widx <= 46) : (widx += 1) {
-        const w = raw[widx];
-        model_arr[midx] = @truncate(w >> 8);
-        model_arr[midx + 1] = @truncate(w & 0xFF);
-        midx += 2;
-    }
-
-    // Trim trailing spaces
-    var model_len: usize = 40;
-    while (model_len > 0) : (model_len -= 1) {
-        if (model_arr[model_len - 1] != ' ' and model_arr[model_len - 1] != 0) break;
-    }
-    if (model_len < model_arr.len) model_arr[model_len] = 0;
+    // Extract model string (Words 27-46 of REG_DATA response)
+    std.mem.byteSwapAllFields([20]u16, raw[27..47]);
+    var model: [40]u8 = .{0} ** 40;
+    const trimmed = std.mem.trim(u8, std.mem.asBytes(raw[27..47]), " \x00");
+    @memcpy(model[0..trimmed.len], trimmed);
 
     const removable = (raw[0] & 0x80) != 0;
 
     logger.debug("identified {s} {s}: {s} (removable: {s})", .{
         @tagName(channel.channel_type),
         @tagName(position),
-        model_arr[0..model_len],
+        std.mem.trim(u8, &model, " \x00"),
         if (removable) "yes" else "no",
     });
 
@@ -201,7 +163,7 @@ fn parseIdentifyData(channel: *const Channel, position: Channel.DrivePosition) D
         .drive_type = .ATAPI,
         .channel = channel.channel_type,
         .position = position,
-        .model = model_arr,
+        .model = model,
         .capacity = capacity,
         .removable = removable,
     };
@@ -212,13 +174,13 @@ fn parseIdentifyData(channel: *const Channel, position: Channel.DrivePosition) D
 /// Instead, we must check for a specific "Signature" in the Cylinder/LBA registers after a soft reset.
 pub fn detectDrive(channel: *const Channel, position: Channel.DrivePosition) ?DriveInfo {
     // 1. Select drive
-    const select: u8 = if (position == .Master) 0xA0 else 0xB0;
+    const select: u8 = if (position == .Master) constants.ATA.SELECT_MASTER else constants.ATA.SELECT_SLAVE;
     cpu.outb(channel.base + constants.ATA.REG_DEVICE, select);
     cpu.io_wait();
 
     // 2. Send Software Reset (bit 2 of Control Register)
     // This resets the drive logic but keeps the configuration.
-    cpu.outb(channel.ctrl, 0x04);
+    cpu.outb(channel.ctrl, constants.ATA.CTRL_SRST);
     cpu.io_wait();
     cpu.outb(channel.ctrl, 0x00); // Clear reset
     cpu.io_wait();
@@ -243,7 +205,7 @@ pub fn detectDrive(channel: *const Channel, position: Channel.DrivePosition) ?Dr
 
         // 6. Wait for data
         const status = common.waitForData(channel.base, 1000) catch return null;
-        if (status & constants.ATA.STATUS_ERROR != 0) return null;
+        if (status.err) return null;
 
         // 7. Parse identification data (similar structure to ATA IDENTIFY)
         return parseIdentifyData(channel, position);

--- a/src/drivers/ide/channel.zig
+++ b/src/drivers/ide/channel.zig
@@ -1,0 +1,113 @@
+const std = @import("std");
+const cpu = @import("../../cpu.zig");
+const timer = @import("../../timer.zig");
+const scheduler = @import("../../task/scheduler.zig");
+const wait_queue = @import("../../task/wait_queue.zig");
+const Mutex = @import("../../task/semaphore.zig").Mutex;
+const ide = @import("ide.zig");
+const constants = @import("constants.zig");
+const types = @import("types.zig");
+const common = @import("common.zig");
+
+const Allocator = std.mem.Allocator;
+const logger = std.log.scoped(.IDE_Channel);
+
+const pci = @import("../pci/pci.zig");
+
+pub const ChannelType = enum { Primary, Secondary };
+pub const DrivePosition = enum { Master, Slave };
+
+pub const Interface = packed struct {
+    index: u8 = 0,
+    device: *pci.PCIDevice = undefined,
+};
+
+base: u16,
+ctrl: u16,
+channel_type: ChannelType,
+irq: u8,
+mutex: Mutex = .{},
+interface: Interface = .{},
+
+const Self = @This();
+
+pub fn reset(self: *Self) void {
+    cpu.outb(self.ctrl, 0x04);
+    for (0..100) |_| cpu.io_wait();
+
+    cpu.outb(self.ctrl, 0x00);
+    for (0..1000) |_| cpu.io_wait();
+
+    _ = cpu.inb(self.base + constants.ATA.REG_STATUS);
+    _ = cpu.inb(self.base + constants.ATA.REG_ERROR_READ);
+}
+
+/// Retrieves every channel for a given IDE interface.
+pub fn get_channels(allocator: Allocator, controller: *const pci.PCIDevice) ?[]Self {
+    var channels: std.ArrayListAligned(Self, .@"4") = .empty;
+    defer channels.deinit(allocator);
+
+    const interface = controller.getIDEInterface() orelse return null;
+
+    // Default values for legacy IDE controllers
+    // TODO: These values are hard-coded for the first controller
+    // Handling more interfaces may require to manually configure the pci BARs etc I guess
+    var primary_base: u16 = 0x1F0;
+    var primary_ctrl: u16 = 0x3F6;
+    var secondary_base: u16 = 0x170;
+    var secondary_ctrl: u16 = 0x376;
+
+    if (interface.isPCINative()) {
+        primary_base = @truncate(controller.bars[0] & 0xFFFC);
+        primary_ctrl = @truncate(controller.bars[1] & 0xFFFC);
+        secondary_base = @truncate(controller.bars[2] & 0xFFFC);
+        secondary_ctrl = @truncate(controller.bars[3] & 0xFFFC);
+    }
+    if (primary_base != 0) {
+        channels.append(allocator, Self{
+            .base = primary_base,
+            .ctrl = primary_ctrl,
+            .channel_type = .Primary,
+            .irq = if (interface.isPCINative()) controller.irq_line else 14,
+        }) catch return null;
+    }
+    if (secondary_base != 0) {
+        channels.append(allocator, Self{
+            .base = secondary_base,
+            .ctrl = secondary_ctrl,
+            .channel_type = .Secondary,
+            .irq = if (interface.isPCINative()) controller.irq_line else 15,
+        }) catch return null;
+    }
+
+    return channels.toOwnedSlice(allocator) catch null;
+}
+
+/// Retrieves every channel for a every IDE interface.
+pub fn get_all_channels(allocator: Allocator) ?[]Self {
+    var list: std.ArrayList(Self) = .empty;
+    defer list.deinit(allocator);
+
+    // TODO: Handle multiple IDE controllers
+    // For now, only the first one is used
+    const interfaces = ide.interfaces[0..1];
+
+    for (interfaces, 0..) |*controller, idx| {
+        const chans = get_channels(allocator, controller);
+        if (chans == null or chans.?.len == 0) {
+            logger.warn("0x{x}: No channels found for interface", .{controller.device_id});
+            continue;
+        }
+        defer allocator.free(chans.?);
+        for (chans.?) |*chan| chan.interface = .{ .index = @truncate(idx), .device = controller };
+        list.appendSlice(allocator, chans.?) catch |err| {
+            logger.warn("0x{x}: Failed to retrieve channels for : {s}", .{
+                controller.device_id,
+                @errorName(err),
+            });
+            continue;
+        };
+        controller.enableDevice();
+    }
+    return list.toOwnedSlice(allocator) catch null;
+}

--- a/src/drivers/ide/channel.zig
+++ b/src/drivers/ide/channel.zig
@@ -32,7 +32,7 @@ interface: Interface = .{},
 const Self = @This();
 
 pub fn reset(self: *Self) void {
-    cpu.outb(self.ctrl, 0x04);
+    cpu.outb(self.ctrl, constants.ATA.CTRL_SRST);
     for (0..100) |_| cpu.io_wait();
 
     cpu.outb(self.ctrl, 0x00);
@@ -52,10 +52,10 @@ pub fn get_channels(allocator: Allocator, controller: *const pci.PCIDevice) ?[]S
     // Default values for legacy IDE controllers
     // TODO: These values are hard-coded for the first controller
     // Handling more interfaces may require to manually configure the pci BARs etc I guess
-    var primary_base: u16 = 0x1F0;
-    var primary_ctrl: u16 = 0x3F6;
-    var secondary_base: u16 = 0x170;
-    var secondary_ctrl: u16 = 0x376;
+    var primary_base: u16 = constants.ATA.PRIMARY_BASE;
+    var primary_ctrl: u16 = constants.ATA.PRIMARY_CTRL;
+    var secondary_base: u16 = constants.ATA.SECONDARY_BASE;
+    var secondary_ctrl: u16 = constants.ATA.SECONDARY_CTRL;
 
     if (interface.isPCINative()) {
         primary_base = @truncate(controller.bars[0] & 0xFFFC);
@@ -68,7 +68,7 @@ pub fn get_channels(allocator: Allocator, controller: *const pci.PCIDevice) ?[]S
             .base = primary_base,
             .ctrl = primary_ctrl,
             .channel_type = .Primary,
-            .irq = if (interface.isPCINative()) controller.irq_line else 14,
+            .irq = if (interface.isPCINative()) controller.irq_line else constants.ATA.PRIMARY_IRQ,
         }) catch return null;
     }
     if (secondary_base != 0) {
@@ -76,7 +76,7 @@ pub fn get_channels(allocator: Allocator, controller: *const pci.PCIDevice) ?[]S
             .base = secondary_base,
             .ctrl = secondary_ctrl,
             .channel_type = .Secondary,
-            .irq = if (interface.isPCINative()) controller.irq_line else 15,
+            .irq = if (interface.isPCINative()) controller.irq_line else constants.ATA.SECONDARY_IRQ,
         }) catch return null;
     }
 
@@ -99,7 +99,7 @@ pub fn get_all_channels(allocator: Allocator) ?[]Self {
             continue;
         }
         defer allocator.free(chans.?);
-        for (chans.?) |*chan| chan.interface = .{ .index = @truncate(idx), .device = controller };
+        for (chans.?) |*chan| chan.interface = .{ .index = @intCast(idx), .device = controller };
         list.appendSlice(allocator, chans.?) catch |err| {
             logger.warn("0x{x}: Failed to retrieve channels for : {s}", .{
                 controller.device_id,

--- a/src/drivers/ide/common.zig
+++ b/src/drivers/ide/common.zig
@@ -1,0 +1,120 @@
+const std = @import("std");
+const cpu = @import("../../cpu.zig");
+const ide = @import("ide.zig");
+const timer = @import("../../timer.zig");
+const constants = @import("constants.zig");
+const types = @import("types.zig");
+const DrivePosition = @import("channel.zig").DrivePosition;
+const Channel = @import("channel.zig");
+const common = @import("common.zig");
+
+pub fn waitForReady(base: u16, timeout_ms: usize) types.IDEError!u8 {
+    const deadline = timer.get_time_since_boot() + timeout_ms;
+
+    while (true) {
+        const status = cpu.inb(base + constants.ATA.REG_STATUS);
+        if ((status & constants.ATA.STATUS_BUSY) == 0) {
+            if (status & constants.ATA.STATUS_ERROR != 0) {
+                return parseError(base);
+            }
+            return status;
+        }
+        if (timer.get_time_since_boot() >= deadline) {
+            return types.IDEError.Timeout;
+        }
+        cpu.io_wait();
+    }
+}
+
+pub fn waitForData(base: u16, timeout_ms: usize) types.IDEError!u8 {
+    const deadline = timer.get_time_since_boot() + timeout_ms;
+
+    while (true) {
+        const status = cpu.inb(base + constants.ATA.REG_STATUS);
+        if ((status & (constants.ATA.STATUS_BUSY | constants.ATA.STATUS_DRQ)) == constants.ATA.STATUS_DRQ) {
+            return status;
+        }
+        if (timer.get_time_since_boot() >= deadline) {
+            return types.IDEError.Timeout;
+        }
+        cpu.io_wait();
+    }
+}
+
+pub fn waitForDataOrCompletion(base: u16, timeout_ms: usize) types.IDEError!u8 {
+    const deadline = timer.get_time_since_boot() + timeout_ms;
+
+    while (true) {
+        const status = cpu.inb(base + constants.ATA.REG_STATUS);
+        if (status & constants.ATA.STATUS_ERROR != 0) {
+            return parseError(base);
+        }
+        if ((status & constants.ATA.STATUS_BUSY) == 0) {
+            return status;
+        }
+        if (timer.get_time_since_boot() >= deadline) {
+            return types.IDEError.Timeout;
+        }
+        cpu.io_wait();
+    }
+}
+
+pub fn readSectorPIO(base: u16, buf: []u8) void {
+    for (0..256) |i| {
+        const w = cpu.inw(base + constants.ATA.REG_DATA);
+        buf[i * 2] = @truncate(w);
+        buf[i * 2 + 1] = @truncate(w >> 8);
+    }
+}
+
+pub fn writeSectorPIO(base: u16, buf: []const u8) void {
+    for (0..256) |i| {
+        const low = buf[i * 2];
+        const high = buf[i * 2 + 1];
+        const w: u16 = (@as(u16, high) << 8) | low;
+        cpu.outw(base + constants.ATA.REG_DATA, w);
+    }
+}
+
+pub fn parseError(base: u16) types.IDEError {
+    const err = cpu.inb(base + constants.ATA.REG_ERROR_READ);
+    if (err & constants.ATA.ERROR_BAD_BLOCK != 0) return types.IDEError.BadBlock;
+    if (err & constants.ATA.ERROR_UNCORRECTABLE != 0) return types.IDEError.UncorrectableError;
+    if (err & constants.ATA.ERROR_MEDIA_CHANGED != 0) return types.IDEError.MediaChanged;
+    if (err & constants.ATA.ERROR_ID_MARK_NOT_FOUND != 0) return types.IDEError.SectorNotFound;
+    if (err & constants.ATA.ERROR_MEDIA_CHANGE_REQ != 0) return types.IDEError.MediaChangeRequested;
+    if (err & constants.ATA.ERROR_CMD_ABORTED != 0) return types.IDEError.CommandAborted;
+    if (err & constants.ATA.ERROR_TRACK0_NOT_FOUND != 0) return types.IDEError.Track0NotFound;
+    if (err & constants.ATA.ERROR_ADDR_MARK_NOT_FOUND != 0) return types.IDEError.AddressMarkNotFound;
+    return types.IDEError.UnknownError;
+}
+
+pub fn waitNs(ns: u32) void {
+    for (0..ns / 30) |_| {
+        cpu.io_wait();
+    }
+}
+
+/// Select LBA device with proper flags
+pub fn selectLBADevice(drive_type: ide.DriveType, op: *@import("ide.zig").IDEOperation) void {
+    switch (drive_type) {
+        .ATA => {
+            const baseFlag: u8 = 0xE0; // LBA mode + always set bits
+            const selFlag: u8 = if (op.position == DrivePosition.Master) 0 else 0x10;
+            const regDev = baseFlag | selFlag | @as(u8, @intCast((op.lba >> 24) & 0x0F));
+
+            cpu.outb(op.channel.base + constants.ATA.REG_DEVICE, regDev);
+        },
+        .ATAPI => {
+            const baseFlag: u8 = 0xA0; // ATAPI LBA mode + always set bits
+            const selFlag: u8 = if (op.position == DrivePosition.Master) 0 else 0x10;
+            const regDev = baseFlag | selFlag;
+
+            cpu.outb(op.channel.base + constants.ATA.REG_DEVICE, regDev);
+        },
+        .Unknown => unreachable,
+    }
+
+    // common.waitNs(400);
+    cpu.io_wait();
+}

--- a/src/drivers/ide/common.zig
+++ b/src/drivers/ide/common.zig
@@ -8,13 +8,13 @@ const DrivePosition = @import("channel.zig").DrivePosition;
 const Channel = @import("channel.zig");
 const common = @import("common.zig");
 
-pub fn waitForReady(base: u16, timeout_ms: usize) types.IDEError!u8 {
+pub fn waitForReady(base: u16, timeout_ms: usize) types.IDEError!types.Status {
     const deadline = timer.get_time_since_boot() + timeout_ms;
 
     while (true) {
-        const status = cpu.inb(base + constants.ATA.REG_STATUS);
-        if ((status & constants.ATA.STATUS_BUSY) == 0) {
-            if (status & constants.ATA.STATUS_ERROR != 0) {
+        const status: types.Status = @bitCast(cpu.inb(base + constants.ATA.REG_STATUS));
+        if (!status.busy) {
+            if (status.err) {
                 return parseError(base);
             }
             return status;
@@ -26,12 +26,12 @@ pub fn waitForReady(base: u16, timeout_ms: usize) types.IDEError!u8 {
     }
 }
 
-pub fn waitForData(base: u16, timeout_ms: usize) types.IDEError!u8 {
+pub fn waitForData(base: u16, timeout_ms: usize) types.IDEError!types.Status {
     const deadline = timer.get_time_since_boot() + timeout_ms;
 
     while (true) {
-        const status = cpu.inb(base + constants.ATA.REG_STATUS);
-        if ((status & (constants.ATA.STATUS_BUSY | constants.ATA.STATUS_DRQ)) == constants.ATA.STATUS_DRQ) {
+        const status: types.Status = @bitCast(cpu.inb(base + constants.ATA.REG_STATUS));
+        if (status.drq and !status.busy) {
             return status;
         }
         if (timer.get_time_since_boot() >= deadline) {
@@ -41,15 +41,15 @@ pub fn waitForData(base: u16, timeout_ms: usize) types.IDEError!u8 {
     }
 }
 
-pub fn waitForDataOrCompletion(base: u16, timeout_ms: usize) types.IDEError!u8 {
+pub fn waitForDataOrCompletion(base: u16, timeout_ms: usize) types.IDEError!types.Status {
     const deadline = timer.get_time_since_boot() + timeout_ms;
 
     while (true) {
-        const status = cpu.inb(base + constants.ATA.REG_STATUS);
-        if (status & constants.ATA.STATUS_ERROR != 0) {
+        const status: types.Status = @bitCast(cpu.inb(base + constants.ATA.REG_STATUS));
+        if (status.err) {
             return parseError(base);
         }
-        if ((status & constants.ATA.STATUS_BUSY) == 0) {
+        if (!status.busy) {
             return status;
         }
         if (timer.get_time_since_boot() >= deadline) {

--- a/src/drivers/ide/common.zig
+++ b/src/drivers/ide/common.zig
@@ -95,14 +95,7 @@ pub fn waitNs(ns: u32) void {
     }
 }
 
-/// Select LBA device with proper flags
-pub fn selectLBADevice(drive_type: ide.DriveType, op: *@import("ide.zig").IDEOperation) void {
-    const reg: u8 = @bitCast(switch (drive_type) {
-        .ATA => types.DeviceRegister.ataLBA28(op.position, op.lba),
-        .ATAPI => types.DeviceRegister.select(op.position),
-        .Unknown => unreachable,
-    });
-
-    cpu.outb(op.channel.base + constants.ATA.REG_DEVICE, reg);
+pub fn selectDevice(base: u16, reg: types.DeviceRegister) void {
+    cpu.outb(base + constants.ATA.REG_DEVICE, @bitCast(reg));
     cpu.io_wait();
 }

--- a/src/drivers/ide/common.zig
+++ b/src/drivers/ide/common.zig
@@ -97,24 +97,12 @@ pub fn waitNs(ns: u32) void {
 
 /// Select LBA device with proper flags
 pub fn selectLBADevice(drive_type: ide.DriveType, op: *@import("ide.zig").IDEOperation) void {
-    switch (drive_type) {
-        .ATA => {
-            const baseFlag: u8 = 0xE0; // LBA mode + always set bits
-            const selFlag: u8 = if (op.position == DrivePosition.Master) 0 else 0x10;
-            const regDev = baseFlag | selFlag | @as(u8, @intCast((op.lba >> 24) & 0x0F));
-
-            cpu.outb(op.channel.base + constants.ATA.REG_DEVICE, regDev);
-        },
-        .ATAPI => {
-            const baseFlag: u8 = 0xA0; // ATAPI LBA mode + always set bits
-            const selFlag: u8 = if (op.position == DrivePosition.Master) 0 else 0x10;
-            const regDev = baseFlag | selFlag;
-
-            cpu.outb(op.channel.base + constants.ATA.REG_DEVICE, regDev);
-        },
+    const reg: u8 = @bitCast(switch (drive_type) {
+        .ATA => types.DeviceRegister.ataLBA28(op.position, op.lba),
+        .ATAPI => types.DeviceRegister.select(op.position),
         .Unknown => unreachable,
-    }
+    });
 
-    // common.waitNs(400);
+    cpu.outb(op.channel.base + constants.ATA.REG_DEVICE, reg);
     cpu.io_wait();
 }

--- a/src/drivers/ide/constants.zig
+++ b/src/drivers/ide/constants.zig
@@ -9,14 +9,29 @@ pub const ATA = struct {
     pub const REG_DEVICE: u16 = 0x06;
     pub const REG_STATUS: u16 = 0x07;
     pub const REG_COMMAND: u16 = 0x07;
-    pub const REG_ALT_STATUS: u16 = 0x00;
+
+    pub const SELECT_MASTER: u8 = 0xA0;
+    pub const SELECT_SLAVE: u8 = 0xB0;
 
     pub const CMD_READ_SECTORS: u8 = 0x20;
     pub const CMD_WRITE_SECTORS: u8 = 0x30;
     pub const CMD_IDENTIFY: u8 = 0xEC;
     pub const CMD_IDENTIFY_PACKET: u8 = 0xA1;
     pub const CMD_PACKET: u8 = 0xA0;
-    pub const CMD_FLUSH_CACHE: u8 = 0xE7;
+
+    // Legacy Controller IO Ports & IRQs
+    pub const PRIMARY_BASE: u16 = 0x1F0;
+    pub const PRIMARY_CTRL: u16 = 0x3F6;
+    pub const PRIMARY_IRQ: u8 = 14;
+
+    pub const SECONDARY_BASE: u16 = 0x170;
+    pub const SECONDARY_CTRL: u16 = 0x376;
+    pub const SECONDARY_IRQ: u8 = 15;
+
+    // Device Control Register bits
+    // Software Reset:
+    //  - Sends a reset signal to each drive on the bus (both master and slave)
+    pub const CTRL_SRST: u8 = 0x04;
 
     pub const STATUS_BUSY: u8 = 0x80;
     pub const STATUS_READY: u8 = 0x40;
@@ -38,23 +53,33 @@ pub const ATA = struct {
 };
 
 pub const ATAPI = struct {
-    pub const CMD_TEST_UNIT_READY: u8 = 0x00;
-    pub const CMD_REQUEST_SENSE: u8 = 0x03;
     pub const CMD_READ10: u8 = 0x28;
     pub const CMD_READ_CAPACITY: u8 = 0x25;
-    pub const CMD_READ_TOC: u8 = 0x43;
-    pub const CMD_GET_CONFIGURATION: u8 = 0x46;
-    pub const CMD_READ_DISC_INFO: u8 = 0x51;
 
     pub const PACKET_SIZE: usize = 12;
 
-    pub const SENSE_NO_SENSE: u8 = 0x00;
-    pub const SENSE_NOT_READY: u8 = 0x02;
-    pub const SENSE_MEDIUM_ERROR: u8 = 0x03;
-    pub const SENSE_HARDWARE_ERROR: u8 = 0x04;
-    pub const SENSE_ILLEGAL_REQUEST: u8 = 0x05;
-    pub const SENSE_UNIT_ATTENTION: u8 = 0x06;
-
     pub const SIGNATURE_MID: u8 = 0x14;
     pub const SIGNATURE_HIGH: u8 = 0xEB;
+};
+
+pub const SCSI = struct {
+    pub const Read10 = packed struct {
+        opcode: u8,
+        reserved1: u8,
+        lba: u32,
+        reserved2: u8,
+        transfer_len: u16,
+        control: u8,
+        pad: u16, // Padding to 12 bytes
+    };
+
+    pub const ReadCapacity = packed struct {
+        opcode: u8,
+        reserved1: u8,
+        lba: u32,
+        reserved2: u16,
+        pmi: u8, // Partial Medium Indicator
+        control: u8, // Control
+        pad: u16, // Padding to 12 bytes
+    };
 };

--- a/src/drivers/ide/constants.zig
+++ b/src/drivers/ide/constants.zig
@@ -1,0 +1,60 @@
+pub const ATA = struct {
+    pub const REG_DATA: u16 = 0x00;
+    pub const REG_ERROR_READ: u16 = 0x01;
+    pub const REG_FEATURES: u16 = 0x01;
+    pub const REG_SEC_COUNT: u16 = 0x02;
+    pub const REG_LBA_LOW: u16 = 0x03;
+    pub const REG_LBA_MID: u16 = 0x04;
+    pub const REG_LBA_HIGH: u16 = 0x05;
+    pub const REG_DEVICE: u16 = 0x06;
+    pub const REG_STATUS: u16 = 0x07;
+    pub const REG_COMMAND: u16 = 0x07;
+    pub const REG_ALT_STATUS: u16 = 0x00;
+
+    pub const CMD_READ_SECTORS: u8 = 0x20;
+    pub const CMD_WRITE_SECTORS: u8 = 0x30;
+    pub const CMD_IDENTIFY: u8 = 0xEC;
+    pub const CMD_IDENTIFY_PACKET: u8 = 0xA1;
+    pub const CMD_PACKET: u8 = 0xA0;
+    pub const CMD_FLUSH_CACHE: u8 = 0xE7;
+
+    pub const STATUS_BUSY: u8 = 0x80;
+    pub const STATUS_READY: u8 = 0x40;
+    pub const STATUS_WRITE_FAULT: u8 = 0x20;
+    pub const STATUS_SEEK_COMPLETE: u8 = 0x10;
+    pub const STATUS_DRQ: u8 = 0x08;
+    pub const STATUS_CORRECTED: u8 = 0x04;
+    pub const STATUS_IDX: u8 = 0x02;
+    pub const STATUS_ERROR: u8 = 0x01;
+
+    pub const ERROR_BAD_BLOCK: u8 = 0x80;
+    pub const ERROR_UNCORRECTABLE: u8 = 0x40;
+    pub const ERROR_MEDIA_CHANGED: u8 = 0x20;
+    pub const ERROR_ID_MARK_NOT_FOUND: u8 = 0x10;
+    pub const ERROR_MEDIA_CHANGE_REQ: u8 = 0x08;
+    pub const ERROR_CMD_ABORTED: u8 = 0x04;
+    pub const ERROR_TRACK0_NOT_FOUND: u8 = 0x02;
+    pub const ERROR_ADDR_MARK_NOT_FOUND: u8 = 0x01;
+};
+
+pub const ATAPI = struct {
+    pub const CMD_TEST_UNIT_READY: u8 = 0x00;
+    pub const CMD_REQUEST_SENSE: u8 = 0x03;
+    pub const CMD_READ10: u8 = 0x28;
+    pub const CMD_READ_CAPACITY: u8 = 0x25;
+    pub const CMD_READ_TOC: u8 = 0x43;
+    pub const CMD_GET_CONFIGURATION: u8 = 0x46;
+    pub const CMD_READ_DISC_INFO: u8 = 0x51;
+
+    pub const PACKET_SIZE: usize = 12;
+
+    pub const SENSE_NO_SENSE: u8 = 0x00;
+    pub const SENSE_NOT_READY: u8 = 0x02;
+    pub const SENSE_MEDIUM_ERROR: u8 = 0x03;
+    pub const SENSE_HARDWARE_ERROR: u8 = 0x04;
+    pub const SENSE_ILLEGAL_REQUEST: u8 = 0x05;
+    pub const SENSE_UNIT_ATTENTION: u8 = 0x06;
+
+    pub const SIGNATURE_MID: u8 = 0x14;
+    pub const SIGNATURE_HIGH: u8 = 0xEB;
+};

--- a/src/drivers/ide/ide.zig
+++ b/src/drivers/ide/ide.zig
@@ -1,0 +1,98 @@
+const std = @import("std");
+const logger = std.log.scoped(.driver_ide);
+const allocator = @import("../../memory.zig").smallAlloc.allocator();
+
+const common = @import("common.zig");
+
+pub const ata = @import("ata.zig");
+pub const atapi = @import("atapi.zig");
+
+pub const constants = @import("constants.zig");
+pub const types = @import("types.zig");
+pub const Channel = @import("channel.zig");
+
+pub const IDEError = types.IDEError;
+pub const DriveType = types.DriveType;
+pub const Capacity = types.Capacity;
+pub const Buffer = types.Buffer;
+
+const IOType = @import("../../block/block.zig").IOType;
+
+/// Informations basiques d'un drive (utilisé uniquement pendant la découverte)
+pub const DriveInfo = struct {
+    model: [41]u8,
+    capacity: Capacity,
+    drive_type: DriveType,
+    removable: bool,
+};
+
+/// Structure pour une opération IDE
+pub const IDEOperation = struct {
+    // drive: *IDEDrive,
+    position: Channel.DrivePosition,
+    channel: *Channel,
+    lba: u32,
+    count: u32,
+    buffer: Buffer,
+    io_type: IOType,
+};
+
+const pci = @import("../pci/pci.zig");
+pub var channels: []Channel = undefined;
+pub var interfaces: []pci.PCIDevice = undefined;
+
+/// Initialiser le driver IDE
+pub fn init() !void {
+    logger.debug("Initializing IDE driver...", .{});
+
+    {
+        const list = pci.findIDEControllers();
+        if (list == null or list.?.len == 0) {
+            logger.warn("No IDE interface found", .{});
+            return;
+        }
+        interfaces = list.?;
+
+        logger.debug("Found {} IDE interface", .{interfaces.len});
+    }
+
+    {
+        const list = Channel.get_all_channels(allocator);
+        if (list == null or list.?.len == 0) {
+            logger.warn("No IDE channels found", .{});
+            return;
+        }
+        channels = list.?;
+
+        logger.debug("Found {} IDE channels", .{channels.len});
+    }
+
+    logger.info("IDE driver initialized, {} interface(s) found", .{interfaces.len});
+}
+
+/// Nettoyer le driver IDE
+pub fn deinit() void {
+    allocator.free(channels);
+    allocator.free(interfaces);
+}
+
+/// Effectuer une opération IDE
+pub fn performOperation(drive_type: DriveType, op: *const IDEOperation) IDEError!void {
+    const channel = op.channel;
+
+    // Valider l'opération
+    if (op.lba > 0xFFFFFFF and drive_type == .ATA) {
+        return IDEError.OutOfBounds;
+    }
+
+    // Acquérir le mutex du canal
+    channel.mutex.acquire();
+    defer channel.mutex.release();
+
+    // Effectuer l'opération selon le type de drive
+    if (drive_type == .ATA) {
+        try ata.performPolling(@constCast(op));
+    } else {
+        try atapi.performPolling(@constCast(op));
+    }
+}

--- a/src/drivers/ide/ide.zig
+++ b/src/drivers/ide/ide.zig
@@ -18,9 +18,9 @@ pub const Buffer = types.Buffer;
 
 const IOType = @import("../../block/block.zig").IOType;
 
-/// Informations basiques d'un drive (utilisé uniquement pendant la découverte)
+/// Drive information (used only during discovery)
 pub const DriveInfo = struct {
-    model: [41]u8,
+    model: [40]u8,
     capacity: Capacity,
     drive_type: DriveType,
     removable: bool,
@@ -77,7 +77,7 @@ pub fn deinit() void {
 }
 
 /// Effectuer une opération IDE
-pub fn performOperation(drive_type: DriveType, op: *const IDEOperation) IDEError!void {
+pub fn performOperation(drive_type: DriveType, op: *IDEOperation) IDEError!void {
     const channel = op.channel;
 
     // Valider l'opération
@@ -91,8 +91,8 @@ pub fn performOperation(drive_type: DriveType, op: *const IDEOperation) IDEError
 
     // Effectuer l'opération selon le type de drive
     if (drive_type == .ATA) {
-        try ata.performPolling(@constCast(op));
+        try ata.performPolling(op);
     } else {
-        try atapi.performPolling(@constCast(op));
+        try atapi.performPolling(op);
     }
 }

--- a/src/drivers/ide/types.zig
+++ b/src/drivers/ide/types.zig
@@ -1,0 +1,81 @@
+const Channel = @import("channel.zig");
+
+pub const Buffer = union {
+    read: []u8,
+    write: []const u8,
+};
+
+pub const IDEError = error{
+    InvalidDrive,
+    DriveNotPresent,
+    InvalidCount,
+    BufferTooSmall,
+    Timeout,
+    ReadTimeout,
+    WriteTimeout,
+    ReadError,
+    WriteError,
+    OutOfBounds,
+    NotInitialized,
+    Interrupted,
+    OutOfMemory,
+    TimeoutTooLong,
+    NoControllerFound,
+    PCIError,
+    NotSupported,
+
+    BadBlock,
+    UncorrectableError,
+    MediaChanged,
+    SectorNotFound,
+    MediaChangeRequested,
+    CommandAborted,
+    Track0NotFound,
+    AddressMarkNotFound,
+    UnknownError,
+
+    NoMedia,
+    MediaNotReady,
+    InvalidPacket,
+    PacketTooLarge,
+};
+
+pub const DriveType = enum {
+    ATA,
+    ATAPI,
+    Unknown,
+
+    pub fn toString(self: DriveType) []const u8 {
+        return switch (self) {
+            .ATA => "ATA",
+            .ATAPI => "ATAPI",
+            .Unknown => "Unknown",
+        };
+    }
+};
+
+pub const Capacity = struct {
+    sectors: u32,
+    sector_size: u32,
+
+    pub fn totalSize(self: *const Capacity) u64 {
+        return self.sectors * self.sector_size;
+    }
+};
+
+pub const DriveInfo = struct {
+    drive_type: DriveType,
+    channel: Channel.ChannelType,
+    position: Channel.DrivePosition,
+    model: [41]u8,
+    capacity: Capacity,
+    removable: bool,
+
+    pub fn isATAPI(self: DriveInfo) bool {
+        return self.drive_type == .ATAPI;
+    }
+
+    pub fn isATA(self: DriveInfo) bool {
+        return self.drive_type == .ATA;
+    }
+};

--- a/src/drivers/ide/types.zig
+++ b/src/drivers/ide/types.zig
@@ -52,17 +52,17 @@ pub const Status = packed struct {
 };
 
 pub const DeviceRegister = packed struct(u8) {
-    lba_high: u4 = 0, // LBA bits 24-27 (ATA only)
+    lba_high: u4 = 0,
     dev: enum(u1) { Master = 0, Slave = 1 } = .Master,
     _always1: u1 = 1,
-    lba: u1 = 0, // 1 = LBA mode (ATA), 0 = unused (ATAPI)
+    addressing: enum(u1) { CHS = 0, LBA = 1 } = .CHS,
     _always1b: u1 = 1,
 
     pub fn ataLBA28(position: @import("channel.zig").DrivePosition, lba: u32) DeviceRegister {
         return .{
             .lba_high = @truncate(lba >> 24),
             .dev = if (position == .Master) .Master else .Slave,
-            .lba = 1,
+            .addressing = .LBA,
         };
     }
 

--- a/src/drivers/ide/types.zig
+++ b/src/drivers/ide/types.zig
@@ -51,6 +51,28 @@ pub const Status = packed struct {
     busy: bool,
 };
 
+pub const DeviceRegister = packed struct(u8) {
+    lba_high: u4 = 0, // LBA bits 24-27 (ATA only)
+    dev: enum(u1) { Master = 0, Slave = 1 } = .Master,
+    _always1: u1 = 1,
+    lba: u1 = 0, // 1 = LBA mode (ATA), 0 = unused (ATAPI)
+    _always1b: u1 = 1,
+
+    pub fn ataLBA28(position: @import("channel.zig").DrivePosition, lba: u32) DeviceRegister {
+        return .{
+            .lba_high = @truncate(lba >> 24),
+            .dev = if (position == .Master) .Master else .Slave,
+            .lba = 1,
+        };
+    }
+
+    pub fn select(position: @import("channel.zig").DrivePosition) DeviceRegister {
+        return .{
+            .dev = if (position == .Master) .Master else .Slave,
+        };
+    }
+};
+
 pub const DriveType = enum {
     ATA,
     ATAPI,

--- a/src/drivers/ide/types.zig
+++ b/src/drivers/ide/types.zig
@@ -40,6 +40,17 @@ pub const IDEError = error{
     PacketTooLarge,
 };
 
+pub const Status = packed struct {
+    err: bool,
+    idx: bool,
+    corrected: bool,
+    drq: bool,
+    seek_complete: bool,
+    write_fault: bool,
+    ready: bool,
+    busy: bool,
+};
+
 pub const DriveType = enum {
     ATA,
     ATAPI,
@@ -67,7 +78,7 @@ pub const DriveInfo = struct {
     drive_type: DriveType,
     channel: Channel.ChannelType,
     position: Channel.DrivePosition,
-    model: [41]u8,
+    model: [40]u8,
     capacity: Capacity,
     removable: bool,
 

--- a/src/drivers/pci/device.zig
+++ b/src/drivers/pci/device.zig
@@ -50,9 +50,9 @@ pub fn isSATAController(self: *const Self) bool {
 }
 
 /// Get IDE interface type for this controller
-pub fn getIDEInterface(self: *const Self) ?pci.IDEInterface {
+pub fn getIDEInterface(self: *const Self) ?pci_config.IDEInterface {
     if (!self.isIDEController()) return null;
-    return pci.IDEInterface.fromU8(self.prog_if);
+    return pci_config.IDEInterface.fromU8(self.prog_if);
 }
 
 pub fn decodeBAR(self: *const Self, bar_index: u8) ?pci_config.BAR.Info {

--- a/src/drivers/pci/pci.zig
+++ b/src/drivers/pci/pci.zig
@@ -212,8 +212,8 @@ pub fn enableDevice(bus: u8, device: u5, function: u3) void {
 
 /// Find all devices matching a specific class and optionally subclass
 pub fn findDevicesByClass(class: PCIClass, subclass: ?u8) ?[]PCIDevice {
-    var result = PCIDeviceList.init(allocator);
-    defer result.deinit();
+    var result: PCIDeviceList = .empty;
+    defer result.deinit(allocator);
 
     for (devices.items) |device| {
         if (device.class_code == class) {
@@ -226,7 +226,7 @@ pub fn findDevicesByClass(class: PCIClass, subclass: ?u8) ?[]PCIDevice {
         }
     }
 
-    return result.toOwnedSlice() catch null;
+    return result.toOwnedSlice(allocator) catch null;
 }
 
 /// Find all IDE controllers


### PR DESCRIPTION
## Summary
Introduces an IDE subsystem with ATA hard disk block device support and ATAPI device detection.

### IDE Subsystem (`src/drivers/ide/`)

- **`ide.zig`**: Entry point: PCI controller discovery, channel initialization, drive detection loop.
- **`channel.zig`**: Channel abstraction (Primary/Secondary) with mutex for concurrent access.
- **`ata.zig`**: ATA PIO read/write (LBA28) and drive detection via IDENTIFY.
- **`atapi.zig`**: ATAPI detection (signature check + IDENTIFY PACKET), capacity query (READ CAPACITY), and PIO read (READ10) with automatic chunking for transfers > 65535 sectors.
- **`common.zig`**: Shared helpers: `selectDevice`, `waitForReady`, `waitForData`, PIO sector read/write, error parsing.
- **`constants.zig`**: ATA/ATAPI/SCSI register offsets, commands, and packet structures.
- **`types.zig`**: Typed hardware registers (`Status`, `DeviceRegister` as packed structs), error set, drive info.

### Block Device Driver (`src/drivers/block/ide_hd.zig`)

- Probes detected ATA drives from the IDE subsystem.
- Registers them as GenDisk devices with the block layer.
- Implements `physical_io` callback for the block translator.

### Other Changes

- **`src/boot.zig`**: Init sequence updated to initialize IDE + IDE HD drivers.
- **`src/cpu.zig`**: Added `outsw_bytes`, `insw_bytes`, `outw`, `inw` for 16-bit PIO transfers.
- **`Makefile`**: `QEMU_BOOT_DRIVE` / `QEMU_DRIVE` variables for flexible disk configuration.

---
Depends-on: #221