### PR TITLE
feat(block): partition scanning framework and MBR partition support

### DIFF
--- a/src/block/gendisk.zig
+++ b/src/block/gendisk.zig
@@ -110,3 +110,13 @@ pub fn add_partition(self: *Self, offset: u32, limit: u32) !*Partition {
 
     return partition;
 }
+
+pub fn scan_partitions(self: *Self) void {
+    const partitions = @import("partitions/partitions.zig");
+    partitions.scan(self) catch |e| {
+        std.log.warn("Partition scan failed for {s}: {s}", .{
+            std.mem.sliceTo(&self.name, 0),
+            @errorName(e),
+        });
+    };
+}

--- a/src/block/partition.zig
+++ b/src/block/partition.zig
@@ -25,6 +25,8 @@ total_blocks: u32, // Total logical blocks
 translator: *BlockTranslator, // Handles physical/logical translation
 stats: Statistics = .{},
 readonly: bool = false,
+bootable: bool = false, // Boot flag from MBR
+partition_type: u8 = 0, // Partition type ID (0x83 = Linux, etc.)
 
 /// Read logical blocks (always 512-byte blocks)
 pub fn read(self: *Self, start_block: u32, count: u32, buffer: []u8) BlockError!void {

--- a/src/block/partition.zig
+++ b/src/block/partition.zig
@@ -12,6 +12,7 @@ const dev_t = core.dev_t;
 
 pub const PART_NAME_LEN = 16;
 const GenDisk = @import("gendisk.zig");
+const PartitionType = @import("partitions/mbr.zig").PartitionType;
 
 const errno = @import("../errno.zig").Errno;
 
@@ -20,11 +21,13 @@ const Self = @This();
 devt: dev_t = .{ .major = 0, .minor = 0 },
 partno: core.minor_t,
 disk: *GenDisk,
-name: [PART_NAME_LEN]u8,
+name: [PART_NAME_LEN:0]u8,
 total_blocks: u32, // Total logical blocks
 translator: *BlockTranslator, // Handles physical/logical translation
 stats: Statistics = .{},
 readonly: bool = false,
+bootable: bool = false, // Boot flag from MBR
+partition_type: PartitionType = .Empty,
 
 /// Read logical blocks (always 512-byte blocks)
 pub fn read(self: *Self, start_block: u32, count: u32, buffer: []u8) BlockError!void {

--- a/src/block/partitions/mbr.zig
+++ b/src/block/partitions/mbr.zig
@@ -1,0 +1,305 @@
+// MBR (Master Boot Record) Partition Table Parser
+//
+// Layout at sector 0, offset 0x1BE:
+// +-------+------------------+
+// | Bytes | Content          |
+// +-------+------------------+
+// | 0-445 | Boot code        |
+// | 446   | Partition 1      |
+// | 462   | Partition 2      |
+// | 478   | Partition 3      |
+// | 494   | Partition 4      |
+// | 510   | Signature 0xAA55 |
+// +-------+------------------+
+
+const std = @import("std");
+
+const partitions = @import("partitions.zig");
+const ParseContext = partitions.ParseContext;
+const ParseResult = partitions.ParseResult;
+
+const blk = @import("../block.zig");
+const GenDisk = @import("../gendisk.zig");
+const STANDARD_BLOCK_SIZE = blk.STANDARD_BLOCK_SIZE;
+
+const logger = std.log.scoped(.mbr);
+
+/// MBR Signature - must be at bytes 510-511
+pub const MBR_SIGNATURE: u16 = 0xAA55;
+
+/// Partition table offset in MBR
+pub const PARTITION_TABLE_OFFSET: usize = 446;
+
+/// Maximum EBR chain depth to prevent infinite loops
+const MAX_EBR_DEPTH: usize = 128;
+
+/// Partition type IDs
+pub const PartitionType = enum(u8) {
+    Empty = 0x00,
+    FAT12 = 0x01,
+    FAT16_Small = 0x04,
+    Extended_CHS = 0x05,
+    FAT16 = 0x06,
+    NTFS = 0x07,
+    FAT32_CHS = 0x0B,
+    FAT32_LBA = 0x0C,
+    FAT16_LBA = 0x0E,
+    Extended_LBA = 0x0F,
+    Hidden_FAT12 = 0x11,
+    Hidden_FAT16 = 0x14,
+    Hidden_FAT32 = 0x1B,
+    Hidden_FAT32_LBA = 0x1C,
+    Hidden_FAT16_LBA = 0x1E,
+    LinuxSwap = 0x82,
+    LinuxNative = 0x83,
+    LinuxExtended = 0x85,
+    LinuxLVM = 0x8E,
+    GPT_Protective = 0xEE,
+    EFI_System = 0xEF,
+    LinuxRAID = 0xFD,
+    _,
+
+    pub fn isExtended(self: PartitionType) bool {
+        return self == .Extended_CHS or self == .Extended_LBA;
+    }
+
+    pub fn isEmpty(self: PartitionType) bool {
+        return self == .Empty;
+    }
+
+    pub fn displayName(self: PartitionType) []const u8 {
+        return switch (self) {
+            .Empty => "Empty",
+            .FAT12 => "FAT12",
+            .FAT16_Small => "FAT16 <32M",
+            .Extended_CHS => "Extended",
+            .FAT16 => "FAT16",
+            .NTFS => "NTFS/exFAT",
+            .FAT32_CHS => "FAT32",
+            .FAT32_LBA => "FAT32 LBA",
+            .FAT16_LBA => "FAT16 LBA",
+            .Extended_LBA => "Extended LBA",
+            .Hidden_FAT12 => "Hidden FAT12",
+            .Hidden_FAT16 => "Hidden FAT16",
+            .Hidden_FAT32 => "Hidden FAT32",
+            .Hidden_FAT32_LBA => "Hidden FAT32 LBA",
+            .Hidden_FAT16_LBA => "Hidden FAT16 LBA",
+            .LinuxSwap => "Linux swap",
+            .LinuxNative => "Linux",
+            .LinuxExtended => "Linux extended",
+            .LinuxLVM => "Linux LVM",
+            .GPT_Protective => "GPT",
+            .EFI_System => "EFI System",
+            .LinuxRAID => "Linux RAID",
+            _ => "Unknown",
+        };
+    }
+};
+
+/// MBR Partition Entry (16 bytes)
+/// Uses extern struct for exact memory layout matching disk format
+pub const PartitionEntry = extern struct {
+    /// Boot indicator: 0x80 = bootable, 0x00 = inactive
+    status: enum(u8) {
+        Inactive = 0x00,
+        Bootable = 0x80,
+    },
+    /// CHS address of first sector (legacy, we use LBA)
+    chs_first: CHS,
+    /// Partition type ID
+    type_id: PartitionType,
+    /// CHS address of last sector (legacy)
+    chs_last: CHS,
+    /// LBA of first sector (little-endian)
+    lba_start: u32 align(1),
+    /// Number of sectors (little-endian)
+    lba_sectors: u32 align(1),
+
+    const CHS = extern struct {
+        head: u8,
+        sector_cylinder: u8, // Sector in bits 0-5, cylinder high in 6-7
+        cylinder_low: u8,
+    };
+
+    pub fn isValid(self: *const PartitionEntry) bool {
+        // Entry is valid if type is not empty and has sectors
+        return !self.type_id.isEmpty() and self.lba_sectors > 0;
+    }
+
+    pub fn isBootable(self: *const PartitionEntry) bool {
+        return self.status == .Bootable;
+    }
+
+    pub fn isExtended(self: *const PartitionEntry) bool {
+        return self.type_id.isExtended();
+    }
+};
+
+/// MBR structure (512 bytes)
+pub const MBR = extern struct {
+    _: [446]u8, // raw MBR bootstrap / reserved bytes
+    partitions: [4]PartitionEntry,
+    signature: u16 align(1),
+
+    comptime {
+        if (@sizeOf(MBR) != 512) {
+            @compileError("MBR struct size must be exactly 512 bytes");
+        }
+        if (@sizeOf(PartitionEntry) != 16) {
+            @compileError("PartitionEntry struct size must be exactly 16 bytes");
+        }
+    }
+
+    /// Cast a sector buffer to MBR
+    /// Returns null if the buffer is too small to hold an MBR
+    pub fn fromSector(sector: []const u8) ?*const MBR {
+        if (sector.len < @sizeOf(MBR)) return null;
+        return @ptrCast(@alignCast(sector.ptr));
+    }
+
+    pub fn isValid(self: *const MBR) bool {
+        // MBR signature is stored as 0x55 0xAA on disk (little-endian = 0xAA55)
+        // Since we're on x86 (little-endian), no conversion needed
+        logger.debug("MBR signature check: 0x{X:0>4} (expected 0x{X:0>4})", .{ self.signature, MBR_SIGNATURE });
+        return self.signature == MBR_SIGNATURE;
+    }
+
+    /// Iterator over valid partition entries
+    pub fn validPartitions(self: *const MBR) ValidPartitionIterator {
+        return .{ .mbr = self, .index = 0 };
+    }
+
+    pub const ValidPartitionIterator = struct {
+        mbr: *const MBR,
+        index: usize,
+
+        pub fn next(self: *ValidPartitionIterator) ?*const PartitionEntry {
+            while (self.index < 4) {
+                const entry = &self.mbr.partitions[self.index];
+                self.index += 1;
+                if (entry.isValid()) {
+                    return entry;
+                }
+            }
+            return null;
+        }
+    };
+};
+
+/// Parse MBR partition table
+pub fn parse(ctx: *ParseContext, sector0: []const u8) ParseResult {
+    const mbr = MBR.fromSector(sector0) orelse return .NotRecognized;
+
+    if (!mbr.isValid()) {
+        return .NotRecognized;
+    }
+
+    logger.debug("MBR signature valid for disk {s}", .{std.mem.sliceTo(&ctx.disk.name, 0)});
+
+    // Parse primary partitions
+    var extended_entry: ?*const PartitionEntry = null;
+
+    for (&mbr.partitions, 0..) |*entry, i| {
+        if (!entry.isValid()) continue;
+
+        if (entry.isExtended()) {
+            // Save extended partition for later processing
+            extended_entry = entry;
+            logger.debug("  Primary {}: Extended at LBA {}, {} sectors", .{
+                i + 1,
+                entry.lba_start,
+                entry.lba_sectors,
+            });
+        } else {
+            logger.debug("  Primary {}: Type 0x{X:0>2} at LBA {}, {} sectors", .{
+                i + 1,
+                @intFromEnum(entry.type_id),
+                entry.lba_start,
+                entry.lba_sectors,
+            });
+
+            const part = ctx.disk.add_partition(entry.lba_start, entry.lba_sectors) catch |e| {
+                logger.warn("Failed to add primary partition {}: {s}", .{ i + 1, @errorName(e) });
+                continue;
+            };
+            part.partition_type = entry.type_id;
+            part.bootable = entry.isBootable();
+        }
+    }
+
+    // Parse extended partition chain
+    if (extended_entry) |ext| {
+        parseExtendedPartitions(ctx, ext.lba_start, ext.lba_start) catch |e| {
+            logger.warn("Failed to parse extended partitions: {s}", .{@errorName(e)});
+        };
+    }
+
+    return .Recognized;
+}
+
+/// Parse the linked list of Extended Boot Records
+fn parseExtendedPartitions(
+    ctx: *ParseContext,
+    ebr_lba: u32,
+    extended_base: u32,
+) !void {
+    var current_lba = ebr_lba;
+    var depth: usize = 0;
+
+    while (depth < MAX_EBR_DEPTH) : (depth += 1) {
+        // Read EBR sector
+        ctx.disk.partition_table.items[0].read(current_lba, 1, ctx.buffer) catch |e| {
+            logger.warn("Failed to read EBR at LBA {}: {s}", .{ current_lba, @errorName(e) });
+            return;
+        };
+
+        const ebr = MBR.fromSector(ctx.buffer) orelse return;
+        if (!ebr.isValid()) {
+            logger.debug("Invalid EBR signature at LBA {}", .{current_lba});
+            return;
+        }
+
+        // First entry: logical partition (relative to current EBR)
+        const logical = &ebr.partitions[0];
+        if (logical.isValid() and !logical.isExtended()) {
+            const absolute_lba = current_lba + logical.lba_start;
+
+            logger.debug("  Logical: Type 0x{X:0>2} at LBA {}, {} sectors", .{
+                @intFromEnum(logical.type_id),
+                absolute_lba,
+                logical.lba_sectors,
+            });
+
+            const part = ctx.disk.add_partition(absolute_lba, logical.lba_sectors) catch |e| {
+                logger.warn("Failed to add logical partition at LBA {}: {s}", .{
+                    absolute_lba,
+                    @errorName(e),
+                });
+                return;
+            };
+            part.partition_type = logical.type_id;
+            part.bootable = logical.isBootable();
+        }
+
+        // Second entry: pointer to next EBR (relative to extended partition start)
+        const next_ebr = &ebr.partitions[1];
+        if (!next_ebr.isValid()) {
+            // End of chain
+            break;
+        }
+
+        // Next EBR LBA is relative to the extended partition base
+        current_lba = extended_base + next_ebr.lba_start;
+    }
+
+    if (depth >= MAX_EBR_DEPTH) {
+        logger.warn("EBR chain exceeded maximum depth ({}), possible corruption", .{MAX_EBR_DEPTH});
+    }
+}
+
+/// Parser registration for the partition framework
+pub const parser = partitions.PartitionParser{
+    .name = "mbr",
+    .priority = 100, // Lower priority than GPT (when added)
+    .parse = parse,
+};

--- a/src/block/partitions/mbr.zig
+++ b/src/block/partitions/mbr.zig
@@ -1,0 +1,267 @@
+// MBR (Master Boot Record) Partition Table Parser
+//
+// Layout at sector 0, offset 0x1BE:
+// +-------+------------------+
+// | Bytes | Content          |
+// +-------+------------------+
+// | 0-445 | Boot code        |
+// | 446   | Partition 1      |
+// | 462   | Partition 2      |
+// | 478   | Partition 3      |
+// | 494   | Partition 4      |
+// | 510   | Signature 0xAA55 |
+// +-------+------------------+
+
+const std = @import("std");
+
+const partitions = @import("partitions.zig");
+const ParseContext = partitions.ParseContext;
+const ParseResult = partitions.ParseResult;
+
+const blk = @import("../block.zig");
+const GenDisk = @import("../gendisk.zig");
+const STANDARD_BLOCK_SIZE = blk.STANDARD_BLOCK_SIZE;
+
+const logger = std.log.scoped(.mbr);
+
+/// MBR Signature - must be at bytes 510-511
+pub const MBR_SIGNATURE: u16 = 0xAA55;
+
+/// Partition table offset in MBR
+pub const PARTITION_TABLE_OFFSET: usize = 446;
+
+/// Maximum EBR chain depth to prevent infinite loops
+const MAX_EBR_DEPTH: usize = 128;
+
+/// Partition type IDs
+pub const PartitionType = enum(u8) {
+    Empty = 0x00,
+    FAT12 = 0x01,
+    FAT16_Small = 0x04,
+    Extended_CHS = 0x05,
+    FAT16 = 0x06,
+    NTFS = 0x07,
+    FAT32_CHS = 0x0B,
+    FAT32_LBA = 0x0C,
+    FAT16_LBA = 0x0E,
+    Extended_LBA = 0x0F,
+    LinuxSwap = 0x82,
+    LinuxNative = 0x83,
+    LinuxLVM = 0x8E,
+    _,
+
+    pub fn isExtended(self: PartitionType) bool {
+        return self == .Extended_CHS or self == .Extended_LBA;
+    }
+
+    pub fn isEmpty(self: PartitionType) bool {
+        return self == .Empty;
+    }
+};
+
+/// MBR Partition Entry (16 bytes)
+/// Uses extern struct for exact memory layout matching disk format
+pub const PartitionEntry = extern struct {
+    /// Boot indicator: 0x80 = bootable, 0x00 = inactive
+    status: enum(u8) {
+        Inactive = 0x00,
+        Bootable = 0x80,
+    },
+    /// CHS address of first sector (legacy, we use LBA)
+    chs_first: CHS,
+    /// Partition type ID
+    type_id: PartitionType,
+    /// CHS address of last sector (legacy)
+    chs_last: CHS,
+    /// LBA of first sector (little-endian)
+    lba_start: u32 align(1),
+    /// Number of sectors (little-endian)
+    lba_sectors: u32 align(1),
+
+    const CHS = extern struct {
+        head: u8,
+        sector_cylinder: u8, // Sector in bits 0-5, cylinder high in 6-7
+        cylinder_low: u8,
+    };
+
+    pub fn isValid(self: *const PartitionEntry) bool {
+        // Entry is valid if type is not empty and has sectors
+        return !self.type_id.isEmpty() and self.lba_sectors > 0;
+    }
+
+    pub fn isBootable(self: *const PartitionEntry) bool {
+        return self.status == .Bootable;
+    }
+
+    pub fn isExtended(self: *const PartitionEntry) bool {
+        return self.type_id.isExtended();
+    }
+};
+
+/// MBR structure (512 bytes)
+pub const MBR = extern struct {
+    _: [446]u8, // raw MBR bootstrap / reserved bytes
+    partitions: [4]PartitionEntry,
+    signature: u16 align(1),
+
+    comptime {
+        if (@sizeOf(MBR) != 512) {
+            @compileError("MBR struct size must be exactly 512 bytes");
+        }
+        if (@sizeOf(PartitionEntry) != 16) {
+            @compileError("PartitionEntry struct size must be exactly 16 bytes");
+        }
+    }
+
+    /// Cast a sector buffer to MBR - uses comptime to verify buffer size
+    pub fn fromSector(sector: []const u8) ?*const MBR {
+        if (sector.len < @sizeOf(MBR)) return null;
+        return @ptrCast(@alignCast(sector.ptr));
+    }
+
+    pub fn isValid(self: *const MBR) bool {
+        // MBR signature is stored as 0x55 0xAA on disk (little-endian = 0xAA55)
+        // Since we're on x86 (little-endian), no conversion needed
+        logger.debug("MBR signature check: 0x{X:0>4} (expected 0x{X:0>4})", .{ self.signature, MBR_SIGNATURE });
+        return self.signature == MBR_SIGNATURE;
+    }
+
+    /// Iterator over valid partition entries
+    pub fn validPartitions(self: *const MBR) ValidPartitionIterator {
+        return .{ .mbr = self, .index = 0 };
+    }
+
+    pub const ValidPartitionIterator = struct {
+        mbr: *const MBR,
+        index: usize,
+
+        pub fn next(self: *ValidPartitionIterator) ?*const PartitionEntry {
+            while (self.index < 4) {
+                const entry = &self.mbr.partitions[self.index];
+                self.index += 1;
+                if (entry.isValid()) {
+                    return entry;
+                }
+            }
+            return null;
+        }
+    };
+};
+
+/// Parse MBR partition table
+pub fn parse(ctx: *ParseContext, sector0: []const u8) ParseResult {
+    const mbr = MBR.fromSector(sector0) orelse return .NotRecognized;
+
+    if (!mbr.isValid()) {
+        return .NotRecognized;
+    }
+
+    logger.debug("MBR signature valid for disk {s}", .{std.mem.sliceTo(&ctx.disk.name, 0)});
+
+    // Parse primary partitions
+    var extended_entry: ?*const PartitionEntry = null;
+
+    for (&mbr.partitions, 0..) |*entry, i| {
+        if (!entry.isValid()) continue;
+
+        if (entry.isExtended()) {
+            // Save extended partition for later processing
+            extended_entry = entry;
+            logger.debug("  Primary {}: Extended at LBA {}, {} sectors", .{
+                i + 1,
+                entry.lba_start,
+                entry.lba_sectors,
+            });
+        } else {
+            logger.debug("  Primary {}: Type 0x{X:0>2} at LBA {}, {} sectors", .{
+                i + 1,
+                @intFromEnum(entry.type_id),
+                entry.lba_start,
+                entry.lba_sectors,
+            });
+
+            const part = ctx.disk.add_partition(entry.lba_start, entry.lba_sectors) catch |e| {
+                logger.warn("Failed to add primary partition {}: {s}", .{ i + 1, @errorName(e) });
+                continue;
+            };
+            part.partition_type = @intFromEnum(entry.type_id);
+            part.bootable = entry.isBootable();
+        }
+    }
+
+    // Parse extended partition chain
+    if (extended_entry) |ext| {
+        parseExtendedPartitions(ctx, ext.lba_start, ext.lba_start) catch |e| {
+            logger.warn("Failed to parse extended partitions: {s}", .{@errorName(e)});
+        };
+    }
+
+    return .Recognized;
+}
+
+/// Parse the linked list of Extended Boot Records
+fn parseExtendedPartitions(
+    ctx: *ParseContext,
+    ebr_lba: u32,
+    extended_base: u32,
+) !void {
+    var current_lba = ebr_lba;
+    var depth: usize = 0;
+
+    while (depth < MAX_EBR_DEPTH) : (depth += 1) {
+        // Read EBR sector
+        ctx.disk.partition_table.items[0].read(current_lba, 1, ctx.buffer) catch |e| {
+            logger.warn("Failed to read EBR at LBA {}: {s}", .{ current_lba, @errorName(e) });
+            return;
+        };
+
+        const ebr = MBR.fromSector(ctx.buffer) orelse return;
+        if (!ebr.isValid()) {
+            logger.debug("Invalid EBR signature at LBA {}", .{current_lba});
+            return;
+        }
+
+        // First entry: logical partition (relative to current EBR)
+        const logical = &ebr.partitions[0];
+        if (logical.isValid() and !logical.isExtended()) {
+            const absolute_lba = current_lba + logical.lba_start;
+
+            logger.debug("  Logical: Type 0x{X:0>2} at LBA {}, {} sectors", .{
+                @intFromEnum(logical.type_id),
+                absolute_lba,
+                logical.lba_sectors,
+            });
+
+            const part = ctx.disk.add_partition(absolute_lba, logical.lba_sectors) catch |e| {
+                logger.warn("Failed to add logical partition at LBA {}: {s}", .{
+                    absolute_lba,
+                    @errorName(e),
+                });
+                return;
+            };
+            part.partition_type = @intFromEnum(logical.type_id);
+            part.bootable = logical.isBootable();
+        }
+
+        // Second entry: pointer to next EBR (relative to extended partition start)
+        const next_ebr = &ebr.partitions[1];
+        if (!next_ebr.isValid()) {
+            // End of chain
+            break;
+        }
+
+        // Next EBR LBA is relative to the extended partition base
+        current_lba = extended_base + next_ebr.lba_start;
+    }
+
+    if (depth >= MAX_EBR_DEPTH) {
+        logger.warn("EBR chain exceeded maximum depth ({}), possible corruption", .{MAX_EBR_DEPTH});
+    }
+}
+
+/// Parser registration for the partition framework
+pub const parser = partitions.PartitionParser{
+    .name = "mbr",
+    .priority = 100, // Lower priority than GPT (when added)
+    .parse = parse,
+};

--- a/src/block/partitions/partitions.zig
+++ b/src/block/partitions/partitions.zig
@@ -1,0 +1,129 @@
+const std = @import("std");
+
+const blk = @import("../block.zig");
+const GenDisk = @import("../gendisk.zig");
+const STANDARD_BLOCK_SIZE = blk.STANDARD_BLOCK_SIZE;
+
+const allocator = @import("../../memory.zig").smallAlloc.allocator();
+
+const logger = std.log.scoped(.partitions);
+
+/// Result of attempting to parse a partition table
+pub const ParseResult = enum {
+    /// Parser recognized and successfully parsed the format
+    Recognized,
+    /// Parser did not recognize this format (try next parser)
+    NotRecognized,
+};
+
+/// Context passed to partition parsers
+pub const ParseContext = struct {
+    disk: *GenDisk,
+    buffer: []u8,
+};
+
+/// Partition parser interface
+pub const PartitionParser = struct {
+    /// Human-readable name for logging
+    name: []const u8,
+    /// Priority for ordering (lower = tried first)
+    /// GPT should be ~50, MBR should be ~100
+    priority: u8,
+    /// Parse function
+    parse: *const fn (*ParseContext, []const u8) ParseResult,
+};
+
+// Parser Registration (comptime)
+
+/// Tuple of all partition parser modules
+/// Each module must export a `parser` constant of type `PartitionParser`
+///
+/// To add a new parser:
+/// 1. Create the parser module
+/// 2. Add it to this tuple
+/// 3. The framework handles the rest at comptime
+const parser_modules = .{
+    @import("mbr.zig"),
+    // Future: @import("gpt.zig"),
+};
+
+/// Comptime-sorted array of parsers by priority
+const sorted_parsers = blk: {
+    var parsers: [parser_modules.len]PartitionParser = undefined;
+
+    // Extract parsers from modules
+    for (parser_modules, 0..) |module, i| {
+        parsers[i] = module.parser;
+    }
+
+    // Sort by priority (insertion sort at comptime)
+    for (1..parsers.len) |i| {
+        const key = parsers[i];
+        var j: usize = i;
+        while (j > 0 and parsers[j - 1].priority > key.priority) {
+            parsers[j] = parsers[j - 1];
+            j -= 1;
+        }
+        parsers[j] = key;
+    }
+
+    break :blk parsers;
+};
+
+// Public API
+
+/// Scan a disk for partition tables
+///
+/// Reads sector 0 and tries each registered parser in priority order.
+/// The first parser that recognizes the format will parse the partition table
+/// and add partitions to the disk.
+///
+/// This function is safe to call even if no partition table exists -
+/// it will simply return without adding any partitions.
+pub fn scan(disk: *GenDisk) !void {
+    // We need to read from the whole disk partition (partition 0)
+    if (disk.partition_table.items.len == 0) {
+        logger.warn("Cannot scan partitions: no whole disk partition", .{});
+        return;
+    }
+
+    const whole_disk = disk.partition_table.items[0];
+
+    // Allocate buffer for reading sectors
+    const buffer = try allocator.alloc(u8, STANDARD_BLOCK_SIZE);
+    defer allocator.free(buffer);
+
+    // Read sector 0
+    whole_disk.read(0, 1, buffer) catch |e| {
+        logger.warn("Failed to read sector 0: {s}", .{@errorName(e)});
+        return e;
+    };
+
+    logger.debug("Read sector 0 successfully, first bytes: {X:0>2} {X:0>2} ... last bytes: {X:0>2} {X:0>2}", .{
+        buffer[0],
+        buffer[1],
+        buffer[buffer.len - 2],
+        buffer[buffer.len - 1],
+    });
+
+    var ctx = ParseContext{
+        .disk = disk,
+        .buffer = buffer,
+    };
+
+    // Try each parser in priority order
+    for (sorted_parsers) |parser| {
+        const result = parser.parse(&ctx, buffer);
+        if (result == .Recognized) {
+            logger.info("Disk {s}: {s} partition table detected", .{
+                std.mem.sliceTo(&disk.name, 0),
+                parser.name,
+            });
+            return;
+        }
+    }
+
+    logger.debug("Disk {s}: no partition table detected", .{
+        std.mem.sliceTo(&disk.name, 0),
+    });
+}

--- a/src/block/partitions/partitions.zig
+++ b/src/block/partitions/partitions.zig
@@ -1,0 +1,126 @@
+const std = @import("std");
+
+const blk = @import("../block.zig");
+const GenDisk = @import("../gendisk.zig");
+const STANDARD_BLOCK_SIZE = blk.STANDARD_BLOCK_SIZE;
+
+const logger = std.log.scoped(.partitions);
+
+/// Result of attempting to parse a partition table
+pub const ParseResult = enum {
+    /// Parser recognized and successfully parsed the format
+    Recognized,
+    /// Parser did not recognize this format (try next parser)
+    NotRecognized,
+};
+
+/// Context passed to partition parsers
+pub const ParseContext = struct {
+    disk: *GenDisk,
+    buffer: []u8,
+};
+
+/// Partition parser interface
+pub const PartitionParser = struct {
+    /// Human-readable name for logging
+    name: []const u8,
+    /// Priority for ordering (lower = tried first)
+    /// GPT should be ~50, MBR should be ~100
+    priority: u8,
+    /// Parse function
+    parse: *const fn (*ParseContext, []const u8) ParseResult,
+};
+
+// Parser Registration (comptime)
+
+/// Tuple of all partition parser modules
+/// Each module must export a `parser` constant of type `PartitionParser`
+///
+/// To add a new parser:
+/// 1. Create the parser module
+/// 2. Add it to this tuple
+/// 3. The framework handles the rest at comptime
+const parser_modules = .{
+    @import("mbr.zig"),
+    // Future: @import("gpt.zig"),
+};
+
+/// Comptime-sorted array of parsers by priority
+const sorted_parsers = blk: {
+    var parsers: [parser_modules.len]PartitionParser = undefined;
+
+    // Extract parsers from modules
+    for (parser_modules, 0..) |module, i| {
+        parsers[i] = module.parser;
+    }
+
+    // Sort by priority (insertion sort at comptime)
+    for (1..parsers.len) |i| {
+        const key = parsers[i];
+        var j: usize = i;
+        while (j > 0 and parsers[j - 1].priority > key.priority) {
+            parsers[j] = parsers[j - 1];
+            j -= 1;
+        }
+        parsers[j] = key;
+    }
+
+    break :blk parsers;
+};
+
+// Public API
+
+/// Scan a disk for partition tables
+///
+/// Reads sector 0 and tries each registered parser in priority order.
+/// The first parser that recognizes the format will parse the partition table
+/// and add partitions to the disk.
+///
+/// This function is safe to call even if no partition table exists -
+/// it will simply return without adding any partitions.
+pub fn scan(disk: *GenDisk) !void {
+    // We need to read from the whole disk partition (partition 0)
+    if (disk.partition_table.items.len == 0) {
+        logger.warn("Cannot scan partitions: no whole disk partition", .{});
+        return;
+    }
+
+    const whole_disk = disk.partition_table.items[0];
+
+    // Allocate buffer for reading sectors
+    var buffer: [STANDARD_BLOCK_SIZE]u8 = undefined;
+
+    // Read sector 0
+    whole_disk.read(0, 1, &buffer) catch |e| {
+        logger.warn("Failed to read sector 0: {s}", .{@errorName(e)});
+        return e;
+    };
+
+    logger.debug("Read sector 0 successfully, first bytes: {X:0>2} {X:0>2} ... last bytes: {X:0>2} {X:0>2}", .{
+        buffer[0],
+        buffer[1],
+        buffer[510],
+        buffer[511],
+    });
+
+    var ctx = ParseContext{
+        .disk = disk,
+        .buffer = &buffer,
+    };
+
+    // Try each parser in priority order
+    for (sorted_parsers) |parser| {
+        const result = parser.parse(&ctx, &buffer);
+        if (result == .Recognized) {
+            logger.info("Disk {s}: {s} partition table detected", .{
+                std.mem.sliceTo(&disk.name, 0),
+                parser.name,
+            });
+            return;
+        }
+    }
+
+    logger.debug("Disk {s}: no partition table detected", .{
+        std.mem.sliceTo(&disk.name, 0),
+    });
+}

--- a/src/block/registry.zig
+++ b/src/block/registry.zig
@@ -93,6 +93,108 @@ pub fn show_partitions(writer: std.io.AnyWriter) void {
     }
 }
 
+pub fn show_lsblk(writer: std.io.AnyWriter, filter: ?[]const u8) void {
+    const BLOCK_SIZE = core.STANDARD_BLOCK_SIZE;
+
+    var it = partitions.inorderIterator();
+    while (it.next()) |entry| {
+        const part = entry.key;
+
+        // Only process whole disk entries (partno == 0)
+        if (part.partno != 0) continue;
+
+        const disk = part.disk;
+        const disk_name = std.mem.sliceTo(&disk.name, 0);
+
+        // If filter is set, check if this disk matches or contains the partition
+        if (filter) |f| {
+            // Check if filter matches disk name
+            const matches_disk = std.mem.eql(u8, disk_name, f);
+            // Check if filter matches any partition name
+            var matches_partition = false;
+            for (disk.partition_table.items) |p| {
+                if (std.mem.eql(u8, std.mem.sliceTo(&p.name, 0), f)) {
+                    matches_partition = true;
+                    break;
+                }
+            }
+            if (!matches_disk and !matches_partition) continue;
+        }
+
+        // Calculate disk size in bytes
+        const whole_disk = disk.partition_table.items[0];
+        const disk_sectors = whole_disk.total_blocks;
+        const disk_bytes = @as(u64, disk_sectors) * BLOCK_SIZE;
+
+        // Print disk header (like fdisk -l)
+        _ = writer.print(
+            "\nDisk {s}: {d} MiB, {d} bytes, {d} sectors\n",
+            .{ disk_name, disk_bytes / (1024 * 1024), disk_bytes, disk_sectors },
+        ) catch {};
+
+        _ = writer.print(
+            "Sector size: {d} bytes\n",
+            .{disk.sector_size},
+        ) catch {};
+
+        // Print partition table header
+        _ = writer.print(
+            "\n{s: <12} {s: <4} {s: >10} {s: >10} {s: >10} {s: >6} {s: >2} {s}\n",
+            .{ "Device", "Boot", "Start", "End", "Sectors", "Size", "Id", "Type" },
+        ) catch {};
+
+        // Print each partition (skip partition 0 = whole disk)
+        for (disk.partition_table.items) |p| {
+            if (p.partno == 0) continue;
+
+            const start = p.translator.logical_offset;
+            const sectors = p.total_blocks;
+            const end = start + sectors - 1;
+            const size_bytes = @as(u64, sectors) * BLOCK_SIZE;
+
+            // Format size nicely
+            var size_buf: [8]u8 = undefined;
+            const size_str = formatSize(size_bytes, &size_buf);
+
+            // Boot flag
+            const boot_str: []const u8 = if (p.bootable) "*" else "";
+
+            _ = writer.print(
+                "{s: <12} {s: <4} {d: >10} {d: >10} {d: >10} {s: >6} {X:0>2} {s}\n",
+                .{
+                    std.mem.sliceTo(&p.name, 0),
+                    boot_str,
+                    start,
+                    end,
+                    sectors,
+                    size_str,
+                    @intFromEnum(p.partition_type),
+                    p.partition_type.displayName(),
+                },
+            ) catch {};
+        }
+    }
+}
+
+/// Format bytes into human-readable size (K, M, G)
+/// Returns a string like "512B", "1K", "2M", "3G", etc.
+fn formatSize(bytes: u64, buf: []u8) []const u8 {
+    const units = [_][]const u8{ "B", "K", "M", "G", "T" };
+    var size: f64 = @floatFromInt(bytes);
+    var unit_idx: usize = 0;
+
+    while (size >= 1024 and unit_idx < units.len - 1) {
+        size /= 1024;
+        unit_idx += 1;
+    }
+
+    if (unit_idx == 0) {
+        return std.fmt.bufPrint(buf, "{d}B", .{@as(u64, @intFromFloat(size))}) catch "?";
+    } else {
+        return std.fmt.bufPrint(buf, "{d:.0}{s}", .{ size, units[unit_idx] }) catch "?";
+    }
+}
+
 pub fn lookup_devt(name: []const u8, partno: minor_t) ?dev_t {
     var it = partitions.inorderIterator();
     while (it.next()) |entry| {

--- a/src/block/registry.zig
+++ b/src/block/registry.zig
@@ -93,6 +93,140 @@ pub fn show_partitions(writer: std.io.AnyWriter) void {
     }
 }
 
+pub fn show_lsblk(writer: std.io.AnyWriter, filter: ?[]const u8) void {
+    const BLOCK_SIZE = core.STANDARD_BLOCK_SIZE;
+
+    var it = partitions.inorderIterator();
+    while (it.next()) |entry| {
+        const part = entry.key;
+
+        // Only process whole disk entries (partno == 0)
+        if (part.partno != 0) continue;
+
+        const disk = part.disk;
+        const disk_name = std.mem.sliceTo(&disk.name, 0);
+
+        // If filter is set, check if this disk matches or contains the partition
+        if (filter) |f| {
+            // Check if filter matches disk name
+            const matches_disk = std.mem.eql(u8, disk_name, f);
+            // Check if filter matches any partition name
+            var matches_partition = false;
+            for (disk.partition_table.items) |p| {
+                if (std.mem.eql(u8, std.mem.sliceTo(&p.name, 0), f)) {
+                    matches_partition = true;
+                    break;
+                }
+            }
+            if (!matches_disk and !matches_partition) continue;
+        }
+
+        // Calculate disk size in bytes
+        const whole_disk = disk.partition_table.items[0];
+        const disk_sectors = whole_disk.total_blocks;
+        const disk_bytes = @as(u64, disk_sectors) * BLOCK_SIZE;
+
+        // Print disk header (like fdisk -l)
+        _ = writer.print(
+            "\nDisk {s}: {d} MiB, {d} bytes, {d} sectors\n",
+            .{ disk_name, disk_bytes / (1024 * 1024), disk_bytes, disk_sectors },
+        ) catch {};
+
+        _ = writer.print(
+            "Sector size: {d} bytes\n",
+            .{disk.sector_size},
+        ) catch {};
+
+        // Print partition table header
+        _ = writer.print(
+            "\n{s: <12} {s: <4} {s: >10} {s: >10} {s: >10} {s: >6} {s: >2} {s}\n",
+            .{ "Device", "Boot", "Start", "End", "Sectors", "Size", "Id", "Type" },
+        ) catch {};
+
+        // Print each partition (skip partition 0 = whole disk)
+        for (disk.partition_table.items) |p| {
+            if (p.partno == 0) continue;
+
+            const start = p.translator.logical_offset;
+            const sectors = p.total_blocks;
+            const end = start + sectors - 1;
+            const size_bytes = @as(u64, sectors) * BLOCK_SIZE;
+
+            // Format size nicely
+            var size_buf: [8]u8 = undefined;
+            const size_str = formatSize(size_bytes, &size_buf);
+
+            // Boot flag
+            const boot_str: []const u8 = if (p.bootable) "*" else "";
+
+            // Partition type name
+            const type_name = partitionTypeName(p.partition_type);
+
+            _ = writer.print(
+                "{s: <12} {s: <4} {d: >10} {d: >10} {d: >10} {s: >6} {X:0>2} {s}\n",
+                .{
+                    std.mem.sliceTo(&p.name, 0),
+                    boot_str,
+                    start,
+                    end,
+                    sectors,
+                    size_str,
+                    p.partition_type,
+                    type_name,
+                },
+            ) catch {};
+        }
+    }
+}
+
+/// Format bytes into human-readable size (K, M, G)
+/// Returns a string like "512B", "1K", "2M", "3G", etc.
+fn formatSize(bytes: u64, buf: []u8) []const u8 {
+    const units = [_][]const u8{ "B", "K", "M", "G", "T" };
+    var size: f64 = @floatFromInt(bytes);
+    var unit_idx: usize = 0;
+
+    while (size >= 1024 and unit_idx < units.len - 1) {
+        size /= 1024;
+        unit_idx += 1;
+    }
+
+    if (unit_idx == 0) {
+        return std.fmt.bufPrint(buf, "{d}B", .{@as(u64, @intFromFloat(size))}) catch "?";
+    } else {
+        return std.fmt.bufPrint(buf, "{d:.0}{s}", .{ size, units[unit_idx] }) catch "?";
+    }
+}
+
+/// Get human-readable partition type name from MBR type ID
+fn partitionTypeName(type_id: u8) []const u8 {
+    return switch (type_id) {
+        0x00 => "Empty",
+        0x01 => "FAT12",
+        0x04 => "FAT16 <32M",
+        0x05 => "Extended",
+        0x06 => "FAT16",
+        0x07 => "NTFS/exFAT",
+        0x0B => "FAT32",
+        0x0C => "FAT32 LBA",
+        0x0E => "FAT16 LBA",
+        0x0F => "Extended LBA",
+        0x11 => "Hidden FAT12",
+        0x14 => "Hidden FAT16",
+        0x1B => "Hidden FAT32",
+        0x1C => "Hidden FAT32 LBA",
+        0x1E => "Hidden FAT16 LBA",
+        0x82 => "Linux swap",
+        0x83 => "Linux",
+        0x85 => "Linux extended",
+        0x8E => "Linux LVM",
+        0xEE => "GPT",
+        0xEF => "EFI System",
+        0xFD => "Linux RAID",
+        else => "Unknown",
+    };
+}
+
 pub fn lookup_devt(name: []const u8, partno: minor_t) ?dev_t {
     var it = partitions.inorderIterator();
     while (it.next()) |entry| {

--- a/src/drivers/block/ide_hd.zig
+++ b/src/drivers/block/ide_hd.zig
@@ -105,6 +105,8 @@ pub fn create_disk(channel: *Channel, info: DriveInfo, channel_idx: usize) !*Gen
         return e;
     };
 
+    disk.scan_partitions();
+
     return disk;
 }
 

--- a/src/shell/default/builtins.zig
+++ b/src/shell/default/builtins.zig
@@ -429,6 +429,14 @@ pub fn partitions(shell: anytype, _: [][]u8) CmdError!void {
     block.show_partitions(shell.writer);
 }
 
+pub fn lsblk(shell: anytype, args: [][]u8) CmdError!void {
+    const block = @import("../../block/registry.zig");
+
+    // lsblk [device_name]
+    const filter: ?[]const u8 = if (args.len >= 2) args[1] else null;
+    block.show_lsblk(shell.writer, filter);
+}
+
 pub fn lookup_devt(shell: anytype, args: [][]u8) CmdError!void {
     if (args.len != 3) return CmdError.InvalidNumberOfArguments;
 


### PR DESCRIPTION
### Summary
This PR implements MBR partition table parsing and introduces a modular partition scanner framework inspired by Linux. It allows the kernel to detect and register partitions from block devices automatically.


### Key Features
- **Partition Scanner Framework**: Extensible architecture using `comptime` registration for zero runtime overhead.
- **MBR Support**: Full parsing of Master Boot Record (MBR) partition tables.
  - Supports 4 primary partitions.
  - Supports Extended Partitions with linked-list EBR (Logical partitions).
- **Tooling**: Added `lsblk` builtin command to list block devices and partitions.
- **Integration**: Updated IDE driver to trigger scanning on device creation.

## Implementation Details
- `src/block/partitions/`: New directory containing scanner core and MBR parser.
- `gendisk.zig`: Added `scan_partitions()` method.
- `ide_hd.zig`: Hooked into device initialization.
- `builtins.zig`: Added `lsblk` command.

## Technical Design

```mermaid
graph TD
    %% Nodes
    subgraph Drivers [Block Device Drivers]
        direction TB
        IDE[IDE Driver]
        RAM[Ramdisk]
    end
    GD[GenDisk]
    
    subgraph Scanning [Scanning Process]
        direction TB
        Scanner[Partition Scanner]
        Parsers[[Parsers: GPT, MBR...]]
    end
    
    Reg[Registry]
    
    subgraph Parts [Partitions]
        direction TB
        P0[Slot 0: Whole Disk]
        P1[Slot 1: Partition 1]
        P2[Slot 2: Partition 2]
    end

    %% Flow
    IDE & RAM -->|Create| GD
    
    GD -->|"1. Add"| P0
    GD -->|"2. Request Scan"| Scanner
    
    Scanner -->|"Iterate"| Parsers
    Parsers --"Match Found"--> Reg
    
    Reg -->|"Register"| P1
    Reg -->|"Register"| P2
```

### Comptime Parser Registration
The partition scanner uses Zig's `comptime` features to build a static list of parsers at compile time.
- Parsers are defined in `partitions.zig` as a tuple of modules.
- The compiler unrolls the iteration over parsers, resulting in **zero runtime overhead** for parser registration/lookup.
- No dynamic memory allocation or global mutable lists are used for the registry itself.

### Scanning Flow
1. **Device Init**: The block driver (e.g., IDE) creates a `GenDisk` and registers partition 0 (Whole Disk).
2. **Auto-Scan**: The driver calls `disk.scan_partitions()`.
3. **Probing**: The scanner iterates through registered parsers (currently MBR only) by priority.
   - It reads sector 0 via the existing "Whole Disk" partition.
   - If a parser returns `Recognized`, the scan stops.
4. **Registration**: Found partitons are added to the global registry as new block devices (e.g., `hda1`, `hda2`), inheriting the parent's IO operations but with offset/size constraints.
5. **Fallibility**: If scanning fails (no table or I/O error), the process fails gracefully, leaving the "Whole Disk" partition accessible.

## Verification
- Validated with disk images containing primary and logical partitions.
- Verified correct offset and size calculations.
- Confirmed `lsblk` output matches expected partition layout.

## Future Work
- **GPT Support**: The priority-based scanner is ready for GPT. We just need to implement the `gpt.zig` parser module and add it to the `partitions.zig` registry.
- **Partition UUIDs**: Future support for UUID/GUID partition identification (essential for robust mounting).

---
Depends-on: #222 