### PR TITLE
(DRAFT) REWORK: Shell uses TTY reference

### DIFF
--- a/src/ci.zig
+++ b/src/ci.zig
@@ -12,8 +12,7 @@ pub fn main(_: usize) u8 {
     const ci_shell = @import("shell/ci/shell.zig");
 
     var shell = ci_shell.Shell.init(
-        tty_s.reader().any(),
-        tty_s.writer().any(),
+        tty_s,
         .{ .colors = false },
         .{ .on_init = &ci_shell.on_init, .on_error = &ci_shell.on_error },
     );

--- a/src/device/tty/tty_struct.zig
+++ b/src/device/tty/tty_struct.zig
@@ -1,5 +1,8 @@
-// Core TTY structure: termios config, line discipline, input buffer,
-// and driver backend pointer.
+// Core TTY structure.
+//
+// Hardware-agnostic part of the TTY subsystem. Holds termios config,
+// line discipline state, input ring buffer, and a pointer to the
+// hardware driver backend (TtyDriver).
 const std = @import("std");
 const termios = @import("termios.zig");
 const TtyDriver = @import("tty_driver.zig");
@@ -15,21 +18,29 @@ index: u8 = 0,
 // No-op driver by default, replaced when a real driver is attached.
 driver: *const TtyDriver = &noop_driver,
 
+// Opaque pointer for driver-private data.
 driver_data: *anyopaque = @ptrFromInt(@as(usize, 0xDEAD)),
 
+/// Current termios configuration.
 config: termios.termios = .{},
 
+/// Input ring buffer.
 input_buffer: [MAX_INPUT]u8 = undefined,
 
-read_head: input_buffer_pos_t = 0, // write cursor (new input goes here)
+/// Points to the end of the input area (where new input is written).
+read_head: input_buffer_pos_t = 0,
 
-read_tail: input_buffer_pos_t = 0, // read cursor (read() consumes from here)
+/// Points to the beginning of the unread part (where read() consumes from).
+read_tail: input_buffer_pos_t = 0,
 
-current_line_begin: input_buffer_pos_t = 0, // start of current canonical line
+/// In canonical mode, points to the start of the current active line.
+current_line_begin: input_buffer_pos_t = 0,
 
-current_line_end: input_buffer_pos_t = 0, // end of processed area
+/// Points to the end of the processed area.
+current_line_end: input_buffer_pos_t = 0,
 
-unprocessed_begin: input_buffer_pos_t = 0, // first unprocessed byte
+/// Points to the first unprocessed byte in the input buffer.
+unprocessed_begin: input_buffer_pos_t = 0,
 
 /// Process input through the line discipline.
 pub fn input(self: *Self, s: []const u8) void {
@@ -134,8 +145,6 @@ fn local_processing(self: *Self) void {
     }
 }
 
-// Output processing
-
 // Output processing: OPOST, ONLCR, OCRNL, ONLRET.
 pub fn output_processing(self: *Self, c: u8) void {
     if (self.config.c_oflag.OPOST) {
@@ -152,19 +161,20 @@ pub fn output_processing(self: *Self, c: u8) void {
     }
 }
 
-// Read / Write interface
-
 pub const WriteError = error{};
 pub const ReadError = error{};
 
 pub const Writer = std.io.GenericWriter(*Self, WriteError, write);
 pub const Reader = std.io.GenericReader(*Self, ReadError, read);
 
-/// Read from the TTY. Blocks until data is available.
+/// Read from the TTY. In canonical mode, blocks until a full line
+/// is available. In raw mode, blocks until at least one byte is ready.
 pub fn read(self: *Self, s: []u8) ReadError!usize {
     var count: usize = 0;
     for (s) |*c| {
         // Block until data is available.
+        // Canonical: wait for a complete line.
+        // Raw: wait for any processed byte.
         while (true) {
             const has_data = if (self.config.c_lflag.ICANON)
                 self.read_tail != self.current_line_begin
@@ -191,27 +201,28 @@ pub fn read(self: *Self, s: []u8) ReadError!usize {
     return count;
 }
 
-/// Write to the TTY output.
+/// Write to the TTY output, going through the driver's write path.
 pub fn write(self: *Self, s: []const u8) WriteError!usize {
     _ = self.driver.write(self, s);
     return s.len;
 }
 
+/// Get a std.io.GenericWriter for this TTY.
 pub fn writer(self: *Self) Writer {
     return Writer{ .context = self };
 }
 
+/// Get a std.io.GenericReader for this TTY.
 pub fn reader(self: *Self) Reader {
     return Reader{ .context = self };
 }
 
-// Driver dispatch helpers
-
-/// Write a string through the driver (used for echo).
+/// Write a string through the driver (used by line discipline for echo).
 fn driver_write(self: *Self, data: []const u8) void {
     _ = self.driver.write(self, data);
 }
 
+/// Put a single character through the driver.
 fn driver_putchar(self: *Self, c: u8) void {
     if (self.driver.put_char) |put_char_fn| {
         put_char_fn(self, c);
@@ -220,12 +231,14 @@ fn driver_putchar(self: *Self, c: u8) void {
     }
 }
 
+/// Flush the driver output buffer.
 pub fn driver_flush(self: *Self) void {
     if (self.driver.flush) |flush_fn| {
         flush_fn(self);
     }
 }
 
+/// Apply new termios and notify the driver.
 pub fn set_termios(self: *Self, new: termios.termios) void {
     const old = self.config;
     self.config = new;

--- a/src/kernel.zig
+++ b/src/kernel.zig
@@ -2,7 +2,7 @@ const DefaultShell = @import("shell/default/shell.zig");
 const tty = @import("./device/tty/tty.zig");
 
 pub fn main(_: usize) u8 {
-    var shell = DefaultShell.Shell.init(tty.get_reader(), tty.get_writer(), .{}, .{
+    var shell = DefaultShell.Shell.init(tty.get_tty(), .{}, .{
         .on_init = DefaultShell.on_init,
         .pre_prompt = DefaultShell.pre_process,
     });

--- a/src/shell/Shell.zig
+++ b/src/shell/Shell.zig
@@ -4,6 +4,7 @@ const colors = @import("colors");
 const allocator = @import("../memory.zig").smallAlloc.allocator();
 const task = @import("../task/task.zig");
 const task_set = @import("../task/task_set.zig");
+const TtyStruct = @import("../device/tty/tty_struct.zig");
 
 pub const CmdError = error{ CommandNotFound, InvalidNumberOfArguments, InvalidParameter, OtherError };
 pub const Config = struct {
@@ -42,14 +43,23 @@ pub fn Shell(comptime _builtins: anytype) type {
             .args = undefined,
             .err = null,
         },
-        reader: std.io.AnyReader = undefined,
-        writer: std.io.AnyWriter = undefined,
+        /// The controlling TTY for this shell.
+        tty: *TtyStruct = undefined,
         hooks: Hooks = Hooks{},
         jobs: std.ArrayList(Job) = .empty,
 
+        /// Reader derived from the TTY.
+        pub inline fn reader(self: *const Self) std.io.AnyReader {
+            return self.tty.reader().any();
+        }
+
+        /// Writer derived from the TTY.
+        pub inline fn writer(self: *const Self) std.io.AnyWriter {
+            return self.tty.writer().any();
+        }
+
         pub fn init(
-            reader: std.io.AnyReader,
-            writer: std.io.AnyWriter,
+            tty_ref: *TtyStruct,
             config: Config,
             hooks: struct {
                 on_init: ?*const anyopaque = null,
@@ -60,8 +70,7 @@ pub fn Shell(comptime _builtins: anytype) type {
             },
         ) Self {
             var ret = Self{
-                .reader = reader,
-                .writer = writer,
+                .tty = tty_ref,
                 .config = config,
             };
             if (hooks.on_init) |h| ret.hooks.on_init = @ptrCast(@alignCast(h));
@@ -141,8 +150,9 @@ pub fn Shell(comptime _builtins: anytype) type {
             self.execution_context.args = &.{};
             if (self.hooks.pre_prompt) |hook| hook(self);
 
-            // Read a line from the reader
-            const slice = self.reader.readUntilDelimiterAlloc(allocator, '\n', max_line_size) catch |e| {
+            // Read a line from the TTY
+            const the_reader = self.reader();
+            const slice = the_reader.readUntilDelimiterAlloc(allocator, '\n', max_line_size) catch |e| {
                 if (e == error.EndOfStream) return;
                 self.execution_context.err = e;
                 if (self.hooks.on_error) |hook| hook(self);
@@ -181,13 +191,13 @@ pub fn Shell(comptime _builtins: anytype) type {
         }
 
         pub fn print(self: *Self, comptime fmt: []const u8, args: anytype) void {
-            self.writer.print(fmt, args) catch {};
+            self.writer().print(fmt, args) catch {};
         }
 
         pub fn print_error(self: *Self, comptime fmt: []const u8, args: anytype) void {
             const red = if (self.config.colors) colors.red else "";
             const reset = if (self.config.colors) colors.reset else "";
-            self.writer.print("{s}Error{s}: " ++ fmt ++ "\n", .{ red, reset } ++ args) catch {};
+            self.writer().print("{s}Error{s}: " ++ fmt ++ "\n", .{ red, reset } ++ args) catch {};
         }
 
         pub fn strerror(_: *Self, err: anyerror) []const u8 {
@@ -210,7 +220,7 @@ pub fn Shell(comptime _builtins: anytype) type {
                 error.OtherError => {}, // specific errors are handled by the command itself
                 error.StreamTooLong => {
                     shell.print_error("Line is too long", .{});
-                    _ = shell.reader.skipUntilDelimiterOrEof('\n') catch {};
+                    _ = shell.reader().skipUntilDelimiterOrEof('\n') catch {};
                 },
                 error.CommandNotFound => shell.print_error("{s}: {s}", .{ args[0], shell.strerror(err) }),
                 error.MaxTokensReached => shell.print_error(

--- a/src/shell/ci/builtins.zig
+++ b/src/shell/ci/builtins.zig
@@ -15,11 +15,11 @@ pub fn kfuzz(shell: anytype, args: [][]u8) CmdError!void {
 
     var buffer: [4096]u8 = undefined;
 
-    var packet = Packet(void).init(shell.writer);
+    var packet = Packet(void).init(shell.writer());
     packet.type = .Success;
     packet.err = if (utils.fuzz(
         @import("../../memory.zig").smallAlloc.allocator(),
-        @constCast(&shell.writer.adaptToNewApi(&buffer).new_interface),
+        @constCast(&shell.writer().adaptToNewApi(&buffer).new_interface),
         nb,
         max_size,
         true,
@@ -39,11 +39,11 @@ pub fn vfuzz(shell: anytype, args: [][]u8) CmdError!void {
 
     var buffer: [4096]u8 = undefined;
 
-    var packet = Packet(void).init(shell.writer);
+    var packet = Packet(void).init(shell.writer());
     packet.type = .Success;
     packet.err = if (utils.fuzz(
         @import("../../memory.zig").bigAlloc.allocator(),
-        @constCast(&shell.writer.adaptToNewApi(&buffer).new_interface),
+        @constCast(&shell.writer().adaptToNewApi(&buffer).new_interface),
         nb,
         max_size,
         true,

--- a/src/shell/ci/shell.zig
+++ b/src/shell/ci/shell.zig
@@ -3,14 +3,14 @@ const std = @import("std");
 pub const Shell = @import("../Shell.zig").Shell(@import("builtins.zig"));
 
 pub fn on_init(shell: *Shell) void {
-    _ = shell.writer.write("CI shell ready on ttyS0\n") catch {};
+    _ = shell.writer().write("CI shell ready on ttyS0\n") catch {};
 }
 
 pub fn on_error(shell: *Shell) void {
     const Packet = @import("packet.zig").Packet;
     const err = shell.execution_context.err orelse unreachable;
 
-    var packet = Packet(void).init(shell.writer);
+    var packet = Packet(void).init(shell.writer());
     packet.err = err;
     packet.send();
 }

--- a/src/shell/default/builtins.zig
+++ b/src/shell/default/builtins.zig
@@ -5,7 +5,7 @@ const utils = @import("../utils.zig");
 const CmdError = @import("../Shell.zig").CmdError;
 const colors = @import("colors");
 
-// TODO Replace printk with format(shell.writer, format, args)...
+// TODO Replace printk with format(shell.writer(), format, args)...
 // As this builtin definitions are only used with graphic mode, it's ok to use printk for now
 const printk = tty.printk;
 
@@ -255,7 +255,7 @@ pub fn kfuzz(shell: anytype, args: [][]u8) CmdError!void {
     var buffer: [4096]u8 = undefined;
     return utils.fuzz(
         @import("../../memory.zig").directMemory.allocator(),
-        @constCast(&shell.writer.adaptToNewApi(&buffer).new_interface),
+        @constCast(&shell.writer().adaptToNewApi(&buffer).new_interface),
         nb,
         max_size,
         false,
@@ -275,7 +275,7 @@ pub fn vfuzz(shell: anytype, args: [][]u8) CmdError!void {
     var buffer: [4096]u8 = undefined;
     return utils.fuzz(
         @import("../../memory.zig").bigAlloc.allocator(),
-        @constCast(&shell.writer.adaptToNewApi(&buffer).new_interface),
+        @constCast(&shell.writer().adaptToNewApi(&buffer).new_interface),
         nb,
         max_size,
         false,
@@ -411,7 +411,7 @@ pub fn pci(shell: anytype, args: [][]u8) CmdError!void {
                 utils.print_error(shell, "No device found ({}:{}.{})", .{ bus, dev, func });
                 break :b CmdError.InvalidParameter;
             };
-            device.printInfo(shell.writer);
+            device.printInfo(shell.writer());
         },
         else => CmdError.InvalidNumberOfArguments,
     };
@@ -421,16 +421,16 @@ pub fn devices(shell: anytype, _: [][]u8) CmdError!void {
     const block = @import("../../device/block/registry.zig");
     const char = @import("../../device/char/registry.zig");
 
-    char.show_char_dev(shell.writer);
-    _ = shell.writer.write("\n") catch {};
+    char.show_char_dev(shell.writer());
+    _ = shell.writer().write("\n") catch {};
 
-    block.show_block_dev(shell.writer);
+    block.show_block_dev(shell.writer());
 }
 
 pub fn partitions(shell: anytype, _: [][]u8) CmdError!void {
     const block = @import("../../device/block/registry.zig");
 
-    block.show_partitions(shell.writer);
+    block.show_partitions(shell.writer());
 }
 
 pub fn lsblk(shell: anytype, args: [][]u8) CmdError!void {
@@ -438,7 +438,7 @@ pub fn lsblk(shell: anytype, args: [][]u8) CmdError!void {
 
     // lsblk [device_name]
     const filter: ?[]const u8 = if (args.len >= 2) args[1] else null;
-    block.show_lsblk(shell.writer, filter);
+    block.show_lsblk(shell.writer(), filter);
 }
 
 pub fn lookup_devt(shell: anytype, args: [][]u8) CmdError!void {
@@ -560,5 +560,5 @@ pub fn lschar(shell: anytype, args: [][]u8) CmdError!void {
     const char_reg = @import("../../device/char/registry.zig");
 
     const filter: ?[]const u8 = if (args.len >= 2) args[1] else null;
-    char_reg.show_lschar(shell.writer, filter);
+    char_reg.show_lschar(shell.writer(), filter);
 }

--- a/src/shell/default/shell.zig
+++ b/src/shell/default/shell.zig
@@ -4,7 +4,7 @@ const colors = @import("colors");
 const tty = @import("../../device/tty/tty.zig");
 
 pub fn on_init(shell: *Shell) void {
-    shell.writer.print("tty {d}, Hello {s}{d}{s}\n", .{
+    shell.writer().print("tty {d}, Hello {s}{d}{s}\n", .{
         @import("../../device/tty/tty.zig").current_tty,
         colors.green,
         42,
@@ -14,7 +14,7 @@ pub fn on_init(shell: *Shell) void {
 }
 
 pub fn on_error(shell: *Shell) void {
-    utils.ensure_newline(shell.writer);
+    utils.ensure_newline(shell.writer());
     shell.defaultErrorHook();
 }
 
@@ -24,5 +24,5 @@ pub fn pre_process(shell: *Shell) void {
 }
 
 pub fn pre_cmd(shell: *Shell) void {
-    utils.ensure_newline(shell.writer);
+    utils.ensure_newline(shell.writer());
 }

--- a/src/shell/utils.zig
+++ b/src/shell/utils.zig
@@ -15,16 +15,16 @@ pub fn ensure_newline(writer: std.io.AnyWriter) void {
 }
 
 pub fn print_error(shell: anytype, comptime msg: []const u8, args: anytype) void {
-    ensure_newline(shell.writer);
-    shell.writer.print(c.red ++ "Error" ++ c.reset ++ ": " ++ msg ++ "\n", args) catch {};
+    ensure_newline(shell.writer());
+    shell.writer().print(c.red ++ "Error" ++ c.reset ++ ": " ++ msg ++ "\n", args) catch {};
 }
 
 pub fn print_prompt(shell: anytype) void {
-    ensure_newline(shell.writer);
+    ensure_newline(shell.writer());
 
     // print the prompt:
     // prompt collor depending on the last command status
-    shell.writer.print("{s}{s}" ++ c.reset ++ " ", .{
+    shell.writer().print("{s}{s}" ++ c.reset ++ " ", .{
         if (shell.execution_context.err != null) c.red else c.cyan,
         prompt,
     }) catch {};


### PR DESCRIPTION
Refactor Shell.zig:
- Replace separate reader/writer fields with a single tty: *TtyStruct
- reader() and writer() are now inline computed getters
- All existing shell.writer/reader usage updated to shell.writer()/reader()

Updated calls:
- kernel.zig: pass tty.get_tty() instead of reader/writer
- ci.zig: pass ttyS0's TtyStruct pointer
- ci/shell.zig, ci/builtins.zig: shell.writer() calls
- default/shell.zig, default/builtins.zig: shell.writer() calls
- utils.zig: shell.writer() calls

---
Depends-on: #231 