### PR TITLE
UPDATE: Transition from SLAB to SLUB allocator

### DIFF
--- a/src/boot.zig
+++ b/src/boot.zig
@@ -94,8 +94,6 @@ export fn init(eax: u32, ebx: u32) callconv(.c) void {
 
     @import("task/signal.zig").SignalQueue.init_cache() catch @panic("Failed to initialized SignalQueue cache");
 
-    @import("task/task.zig").TaskDescriptor.init_cache() catch @panic("Failed to initialized task_descriptor cache");
-
     // The ready_queue and wait_queue init functions are only here to setup their on_terminate task callbacks
     @import("task/ready_queue.zig").init();
     @import("task/wait_queue.zig").init();

--- a/src/memory.zig
+++ b/src/memory.zig
@@ -155,6 +155,9 @@ pub fn init() void {
     logger.debug("\tInitializing direct page allocator...", .{});
     directPageAllocator = DirectPageAllocator.init(paging.high_half);
 
+    const tsc = @import("cpu.zig").read_tsc();
+    @import("memory/object_allocators/slab/slab.zig").init_secret(@truncate(tsc ^ (tsc >> 32)));
+
     logger.debug("\tInitializing slab allocator's global cache...", .{});
     const GlobalCache = @import("memory/object_allocators/slab/cache.zig").GlobalCache;
     globalCache = GlobalCache.init(directPageAllocator.page_allocator()) catch @panic("cannot init globalCache");

--- a/src/memory.zig
+++ b/src/memory.zig
@@ -83,10 +83,13 @@ fn init_medium(medium_begin: paging.PhysicalPtr, medium_size: paging.PhysicalUsi
 
 fn init_physical_memory() void {
     logger.debug("\tInitializing physical memory allocator...", .{});
-    directMemory = MultipoolAllocator.init("dma_kmalloc", directPageAllocator.page_allocator()) catch {
+    directMemory = MultipoolAllocator.init("dma_kmalloc", directPageAllocator.page_allocator(), .{}) catch {
         @panic("cannot cache_init MultipoolAllocator");
     };
-    smallAlloc = MultipoolAllocator.init("kmalloc", virtually_contiguous_page_allocator.page_allocator()) catch {
+    smallAlloc = MultipoolAllocator.init("kmalloc", virtually_contiguous_page_allocator.page_allocator(), .{
+        .sanity = @import("build_options").optimize == .Debug,
+        .poison = @import("build_options").optimize == .Debug,
+    }) catch {
         @panic("cannot cache_init MultipoolAllocator");
     };
     logger.debug("\tPhysical memory allocator initialized", .{});

--- a/src/memory/buddy_allocator.zig
+++ b/src/memory/buddy_allocator.zig
@@ -107,16 +107,15 @@ pub fn BuddyAllocator(comptime max_order: order_t) type {
                 std.mem.alignBackward(idx_t, page_idx, @as(idx_t, 1) << order),
             );
 
-            if (frame.prev) |prev| {
-                prev.next = frame.next;
+            if (frame.state.buddy.prev) |prev| {
+                prev.state.buddy.next = frame.state.buddy.next;
             } else {
-                self.free_lists[order] = frame.next;
+                self.free_lists[order] = frame.state.buddy.next;
             }
-            if (frame.next) |next| {
-                next.prev = frame.prev;
+            if (frame.state.buddy.next) |next| {
+                next.state.buddy.prev = frame.state.buddy.prev;
             }
-            frame.prev = null;
-            frame.next = null;
+            frame.state = .other;
         }
 
         /// add the page frame identified by page_idx to the list of free pages for order order
@@ -125,11 +124,8 @@ pub fn BuddyAllocator(comptime max_order: order_t) type {
                 std.mem.alignBackward(idx_t, page_idx, @as(idx_t, 1) << order),
             );
 
-            frame.prev = null;
-            frame.next = self.free_lists[order];
-            if (frame.next) |next| {
-                next.prev = frame;
-            }
+            frame.state = .{ .buddy = .{ .prev = null, .next = self.free_lists[order] } };
+            if (frame.state.buddy.next) |next| next.state.buddy.prev = frame;
             self.free_lists[order] = frame;
         }
 

--- a/src/memory/object_allocators/multipool_allocator.zig
+++ b/src/memory/object_allocators/multipool_allocator.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const Slab = @import("slab/slab.zig").Slab;
+const Slab = @import("slab/slab.zig");
 const Cache = @import("slab/cache.zig").Cache;
 const PageAllocator = @import("../page_allocator.zig");
 const globalCache = &@import("../../memory.zig").globalCache;
@@ -92,13 +92,15 @@ pub const MultipoolAllocator = struct {
     }
 
     pub fn obj_size(_: *Self, ptr: anytype) !usize {
-        const pfd = globalCache.cache.get_page_frame_descriptor(@ptrCast(@alignCast(ptr)));
-        const slab: *Slab = pfd.state.slab.slab;
-
-        return if (slab.is_obj_in_slab(@ptrCast(@alignCast(ptr))))
-            slab.header.cache.size_obj
-        else
-            error.InvalidArgument;
+        const slab = Slab.resolve_head(@ptrCast(@alignCast(ptr))) catch return error.InvalidArgument;
+        const cache: *Cache = slab.cache();
+        const obj_addr = @intFromPtr(ptr);
+        const base = slab.base_addr();
+        if (obj_addr < base or obj_addr > base + cache.size_obj * cache.obj_per_slab)
+            return error.InvalidArgument;
+        if ((obj_addr - base) % cache.size_obj != 0)
+            return error.InvalidArgument;
+        return cache.size_obj;
     }
 
     fn vtable_alloc(ctx: *anyopaque, len: usize, alignment: Alignment, ret_addr: usize) ?[*]u8 {

--- a/src/memory/object_allocators/multipool_allocator.zig
+++ b/src/memory/object_allocators/multipool_allocator.zig
@@ -93,15 +93,12 @@ pub const MultipoolAllocator = struct {
 
     pub fn obj_size(_: *Self, ptr: anytype) !usize {
         const pfd = globalCache.cache.get_page_frame_descriptor(@ptrCast(@alignCast(ptr)));
-        if (!pfd.flags.slab) return error.InvalidArgument;
-        const slab: ?*Slab = if (pfd.next) |slab| @ptrCast(@alignCast(slab)) else null;
+        const slab: *Slab = pfd.state.slab.slab;
 
-        if (slab) |s| {
-            return if (s.is_obj_in_slab(@ptrCast(@alignCast(ptr))))
-                s.header.cache.size_obj
-            else
-                error.InvalidArgument;
-        } else return error.InvalidArgument;
+        return if (slab.is_obj_in_slab(@ptrCast(@alignCast(ptr))))
+            slab.header.cache.size_obj
+        else
+            error.InvalidArgument;
     }
 
     fn vtable_alloc(ctx: *anyopaque, len: usize, alignment: Alignment, ret_addr: usize) ?[*]u8 {

--- a/src/memory/object_allocators/multipool_allocator.zig
+++ b/src/memory/object_allocators/multipool_allocator.zig
@@ -12,7 +12,7 @@ pub const MultipoolAllocator = struct {
 
     caches: [14]*Cache = undefined,
 
-    pub fn init(comptime name: []const u8, page_allocator: PageAllocator) !Self {
+    pub fn init(comptime name: []const u8, page_allocator: PageAllocator, dbg: Slab.DebugFlags) !Self {
         const CacheDescription = struct {
             name: []const u8,
             size: usize,
@@ -45,6 +45,7 @@ pub const MultipoolAllocator = struct {
                 cache_descriptions[i].size,
                 @alignOf(usize),
                 cache_descriptions[i].order,
+                dbg,
             );
         }
 
@@ -94,11 +95,12 @@ pub const MultipoolAllocator = struct {
     pub fn obj_size(_: *Self, ptr: anytype) !usize {
         const slab = Slab.resolve_head(@ptrCast(@alignCast(ptr))) catch return error.InvalidArgument;
         const cache: *Cache = slab.cache();
-        const obj_addr = @intFromPtr(ptr);
+        const slot_addr = @intFromPtr(ptr);
         const base = slab.base_addr();
-        if (obj_addr < base or obj_addr > base + cache.size_obj * cache.obj_per_slab)
+        const slab_end = base + cache.slot_size * cache.obj_per_slab;
+        if (slot_addr < base or slot_addr + cache.slot_size > slab_end)
             return error.InvalidArgument;
-        if ((obj_addr - base) % cache.size_obj != 0)
+        if ((slot_addr - base) % cache.slot_size != 0)
             return error.InvalidArgument;
         return cache.size_obj;
     }

--- a/src/memory/object_allocators/slab/cache.zig
+++ b/src/memory/object_allocators/slab/cache.zig
@@ -76,9 +76,7 @@ pub const Cache = struct {
         for (0..self.pages_per_slab) |i| {
             const page_addr = @as(usize, @intFromPtr(slab)) + (i * paging.page_size);
             var pfd = self.get_page_frame_descriptor(@ptrFromInt(page_addr));
-            pfd.flags.slab = false;
-            pfd.prev = null;
-            pfd.next = null;
+            pfd.state = .other;
         }
     }
 
@@ -129,9 +127,7 @@ pub const Cache = struct {
             for (0..self.pages_per_slab) |i| {
                 const page_addr = @as(usize, @intFromPtr(obj)) + (i * paging.page_size);
                 var pfd = self.get_page_frame_descriptor(@ptrFromInt(page_addr));
-                pfd.prev = @ptrCast(@alignCast(self));
-                pfd.next = @ptrCast(@alignCast(slab));
-                pfd.flags.slab = true;
+                pfd.state = .{ .slab = .{ .cache = self, .slab = slab } };
             }
             self.unsafe_move_slab(slab, SlabState.Empty);
             self.nb_slab += 1;
@@ -181,13 +177,9 @@ pub const Cache = struct {
 
     pub fn unsafe_free(_: *Self, ptr: *usize) (Slab.Error || BitMap.Error)!void {
         const addr = std.mem.alignBackward(usize, @intFromPtr(ptr), paging.page_size);
-        const page_descriptor = mapping.get_page_frame_descriptor(
-            @ptrFromInt(addr),
-        ) catch return Slab.Error.InvalidArgument;
+        const pfd = mapping.get_page_frame_descriptor(@ptrFromInt(addr)) catch return Slab.Error.InvalidArgument;
 
-        if (page_descriptor.flags.slab == false) return Slab.Error.InvalidArgument;
-        const slab: *Slab = @ptrCast(@alignCast(page_descriptor.next));
-        try slab.free_object(ptr);
+        try pfd.state.slab.slab.free_object(ptr);
     }
 
     // The following methods are the thread safe wrapper to unsafe methods.
@@ -250,9 +242,7 @@ pub const Cache = struct {
 
     pub fn has_obj(self: *Self, obj: *usize) bool {
         const pfd = self.get_page_frame_descriptor(@ptrCast(obj));
-        if (pfd.flags.slab == false) return false;
-        const cache: *Self = @ptrCast(@alignCast(pfd.prev));
-        return cache == self;
+        return pfd.state.slab.cache == self;
     }
 
     pub fn debug(self: *Self) void {

--- a/src/memory/object_allocators/slab/cache.zig
+++ b/src/memory/object_allocators/slab/cache.zig
@@ -3,12 +3,13 @@ const Alignment = std.mem.Alignment;
 const printk = @import("../../../tty/tty.zig").printk;
 const PageAllocator = @import("../../page_allocator.zig");
 const paging = @import("../../paging.zig");
-const page_frame_descriptor = paging.page_frame_descriptor;
-const Slab = @import("slab.zig").Slab;
-const SlabState = @import("slab.zig").SlabState;
+const pfd_t = paging.page_frame_descriptor;
 const BitMap = @import("../../../misc/bitmap.zig").BitMap;
 const mapping = @import("../../mapping.zig");
 const Mutex = @import("../../../task/semaphore.zig").Mutex;
+
+const Slab = @import("slab.zig");
+const SlabState = @import("slab.zig").SlabState;
 
 // DEPRECATED
 const logger = std.log.scoped(.cache);
@@ -22,9 +23,9 @@ pub const Cache = struct {
 
     next: ?*Cache = null,
     prev: ?*Cache = null,
-    slab_full: ?*Slab = null,
-    slab_partial: ?*Slab = null,
-    slab_empty: ?*Slab = null,
+    slab_full: ?Slab = null,
+    slab_partial: ?Slab = null,
+    slab_empty: ?Slab = null,
     page_allocator: PageAllocator = undefined,
     pages_per_slab: usize = 0,
     name: [CACHE_NAME_LEN]u8 = undefined,
@@ -49,20 +50,9 @@ pub const Cache = struct {
             .align_obj = obj_align,
         };
 
-        // Compute the available space for the slab ((page_size * 2^order) - size of slab header)
-        const available = (paging.page_size * new.pages_per_slab) - std.mem.alignForward(
-            usize,
-            @sizeOf(Slab),
-            obj_align,
-        );
+        const total = paging.page_size * new.pages_per_slab;
+        new.obj_per_slab = @intCast(total / new.size_obj);
 
-        new.obj_per_slab = 0;
-        while (true) {
-            const bitmap_size = BitMap.compute_size(new.obj_per_slab + 1);
-            const total_size = bitmap_size + ((new.obj_per_slab + 1) * new.size_obj);
-            if (total_size > available) break;
-            new.obj_per_slab += 1;
-        }
         if (new.obj_per_slab == 0 or new.obj_per_slab >= (1 << 16))
             return Error.InitializationFailed;
 
@@ -72,91 +62,88 @@ pub const Cache = struct {
         return new;
     }
 
-    fn reset_page_frame_descriptor(self: *Self, slab: *Slab) void {
-        for (0..self.pages_per_slab) |i| {
-            const page_addr = @as(usize, @intFromPtr(slab)) + (i * paging.page_size);
-            var pfd = self.get_page_frame_descriptor(@ptrFromInt(page_addr));
-            pfd.state = .other;
+    // Slab list management ----------------------------------------------------
+    //
+    fn unlink(self: *Self, slab: Slab, from: SlabState) void {
+        if (slab.prev()) |prev| {
+            prev.set_next(slab.next());
+        } else switch (from) {
+            .Empty => self.slab_empty = slab.next(),
+            .Partial => self.slab_partial = slab.next(),
+            .Full => self.slab_full = slab.next(),
         }
+        if (slab.next()) |next| next.set_prev(slab.prev());
     }
 
-    fn unlink(self: *Self, slab: *Slab) void {
-        if (slab.header.prev) |prev| prev.header.next = slab.header.next else switch (slab.get_state()) {
-            .Empty => self.slab_empty = slab.header.next,
-            .Partial => self.slab_partial = slab.header.next,
-            .Full => self.slab_full = slab.header.next,
-        }
-        if (slab.header.next) |next| next.header.prev = slab.header.prev;
-    }
-
-    fn link(self: *Self, slab: *Slab, state: SlabState) void {
+    fn link(self: *Self, slab: Slab, state: SlabState) void {
         switch (state) {
             .Empty => {
-                slab.header.next = self.slab_empty;
+                slab.set_next(self.slab_empty);
                 self.slab_empty = slab;
             },
             .Partial => {
-                slab.header.next = self.slab_partial;
+                slab.set_next(self.slab_partial);
                 self.slab_partial = slab;
             },
             .Full => {
-                slab.header.next = self.slab_full;
+                slab.set_next(self.slab_full);
                 self.slab_full = slab;
             },
         }
-        if (slab.header.next) |next| next.header.prev = slab;
-        slab.header.prev = null;
+        if (slab.next()) |next| Slab.from_pfd(next.pfd).set_prev(slab);
+        slab.set_prev(null);
     }
 
-    // Unsafe methods are method implementing the logic without thread safety.
-    // Each unsafe_xxx method has xxx method which simply calls unsafe_xxx wrapped by mutex lock/unlock.
+    // Unsafe methods implement the logic without thread safety.
+    // Each unsafe_xxx method correspond to a xxx method which simply calls unsafe_xxx wrapped by mutex lock/unlock.
     // This is a workaround to prevent deadlocks
     //
-    pub fn unsafe_move_slab(self: *Self, slab: *Slab, state: SlabState) void {
-        self.unlink(slab);
-        self.link(slab, state);
+    pub fn unsafe_move_slab(self: *Self, slab: Slab, from: SlabState, to: SlabState) void {
+        self.unlink(slab, from);
+        self.link(slab, to);
     }
 
     pub fn unsafe_grow(self: *Self, nb_slab: usize) PageAllocator.Error!void {
         for (0..nb_slab) |_| {
-            const obj = try self.page_allocator.alloc_pages(self.pages_per_slab);
-            const slab: *Slab = @ptrCast(@alignCast(obj));
+            const page = try self.page_allocator.alloc_pages(self.pages_per_slab);
+            const slab: Slab = Slab.init_pfds(page, self);
+            const base = slab.base_addr();
 
-            slab.* = Slab.init(self, @ptrCast(obj));
-
-            for (0..self.pages_per_slab) |i| {
-                const page_addr = @as(usize, @intFromPtr(obj)) + (i * paging.page_size);
-                var pfd = self.get_page_frame_descriptor(@ptrFromInt(page_addr));
-                pfd.state = .{ .slab = .{ .cache = self, .slab = slab } };
+            for (0..self.obj_per_slab) |i| {
+                const obj_addr = base + (i * self.size_obj);
+                const obj_ptr: *u16 = @ptrFromInt(obj_addr);
+                obj_ptr.* = if (i + 1 < self.obj_per_slab) @truncate(i + 1) else Slab.FREE_SENTINEL;
             }
-            self.unsafe_move_slab(slab, SlabState.Empty);
+
+            self.link(slab, SlabState.Empty);
             self.nb_slab += 1;
         }
     }
 
     fn unsafe_shrink(self: *Self) void {
         while (self.slab_empty) |slab| {
-            self.unlink(slab);
-            self.reset_page_frame_descriptor(slab);
-            self.page_allocator.free_pages(@ptrCast(@alignCast(slab)), self.pages_per_slab);
+            self.unlink(slab, SlabState.Empty);
+            const base_ptr: paging.VirtualPagePtr = @ptrFromInt(slab.base_addr());
+            slab.reset_pfds(self.pages_per_slab);
+            self.page_allocator.free_pages(base_ptr, self.pages_per_slab);
             self.nb_slab -= 1;
         }
     }
 
-    pub fn unsafe_available_chunks(self: *Self) usize {
+    fn unsafe_available_chunks(self: *Cache) usize {
         var ret: usize = 0;
         var partials = self.slab_partial;
-        while (partials) |p| : (partials = p.header.next) {
-            ret += self.obj_per_slab - p.header.in_use;
+        while (partials) |p| : (partials = p.next()) {
+            ret += self.obj_per_slab - p.in_use();
         }
         var empty = self.slab_empty;
-        while (empty) |e| : (empty = e.header.next) {
+        while (empty) |e| : (empty = e.next()) {
             ret += self.obj_per_slab;
         }
         return ret;
     }
 
-    pub fn unsafe_prepare_alloc(self: *Self, count: usize) !void {
+    fn unsafe_prepare_alloc(self: *Self, count: usize) !void {
         const available = self.available_chunks();
         if (available >= count)
             return;
@@ -165,84 +152,116 @@ pub const Cache = struct {
         try self.unsafe_grow(slabs_needed);
     }
 
-    pub fn unsafe_alloc_one(self: *Self) AllocError!*usize {
-        const slab: ?*Slab = if (self.slab_partial) |slab| slab else if (self.slab_empty) |slab| slab else null;
-        if (slab) |s|
-            return try s.alloc_object()
-        else {
+    fn unsafe_alloc_one(self: *Self) AllocError!*usize {
+        const slab: ?Slab = if (self.slab_partial) |slab| slab else if (self.slab_empty) |slab| slab else null;
+        if (slab) |s| {
+            const next = s.next_free();
+            if (next == Slab.FREE_SENTINEL) return Slab.Error.SlabFull;
+
+            const base = s.base_addr();
+            const obj_addr = base + (next * self.size_obj);
+
+            const is_empty = s.in_use() == 0;
+
+            // Read the next free index from object's
+            const obj_ptr: *u16 = @ptrFromInt(obj_addr);
+            s.set_next_free(obj_ptr.*);
+            s.set_in_use(s.in_use() + 1);
+
+            if (is_empty) {
+                self.unsafe_move_slab(s, SlabState.Empty, SlabState.Partial);
+            } else if (s.next_free() == Slab.FREE_SENTINEL) {
+                self.unsafe_move_slab(s, SlabState.Partial, SlabState.Full);
+            }
+
+            return @ptrFromInt(obj_addr);
+        } else {
             try self.unsafe_grow(1);
             return self.unsafe_alloc_one();
         }
     }
 
-    pub fn unsafe_free(_: *Self, ptr: *usize) (Slab.Error || BitMap.Error)!void {
-        const addr = std.mem.alignBackward(usize, @intFromPtr(ptr), paging.page_size);
-        const pfd = mapping.get_page_frame_descriptor(@ptrFromInt(addr)) catch return Slab.Error.InvalidArgument;
+    pub fn unsafe_free(_: *Self, ptr: *usize) Slab.Error!void {
+        const obj_addr = @intFromPtr(ptr);
+        const slab = Slab.resolve_head(@ptrCast(ptr)) catch return Slab.Error.InvalidArgument;
 
-        try pfd.state.slab.slab.free_object(ptr);
+        const cache = slab.cache();
+        const base = slab.base_addr();
+
+        // Check if the object belongs to this cache
+        if (obj_addr < base or obj_addr >= base + (cache.size_obj * cache.obj_per_slab))
+            return Slab.Error.InvalidArgument;
+        if ((obj_addr - base) % cache.size_obj != 0)
+            return Slab.Error.InvalidArgument;
+
+        const index: u16 = @truncate((obj_addr - base) / cache.size_obj);
+
+        // TODO: Double Free check
+
+        const was_full = slab.next_free() == Slab.FREE_SENTINEL;
+        slab.set_in_use(slab.in_use() - 1);
+
+        // Write the next free index to object's
+        const obj_ptr: *u16 = @ptrFromInt(obj_addr);
+        obj_ptr.* = slab.next_free();
+        slab.set_next_free(index);
+
+        if (was_full) {
+            cache.unsafe_move_slab(slab, SlabState.Full, SlabState.Partial);
+        } else if (slab.in_use() == 0) {
+            cache.unsafe_move_slab(slab, SlabState.Partial, SlabState.Empty);
+        }
     }
 
-    // The following methods are the thread safe wrapper to unsafe methods.
+    // Thread safe wrapper
     //
-    pub fn move_slab(self: *Self, slab: *Slab, state: SlabState) void {
+    pub fn move_slab(self: *Self, slab: Slab, from: SlabState, to: SlabState) void {
         self.lock.acquire();
         defer self.lock.release();
-
-        return self.unsafe_move_slab(slab, state);
+        return self.unsafe_move_slab(slab, from, to);
     }
 
     pub fn grow(self: *Self, nb_slab: usize) PageAllocator.Error!void {
         self.lock.acquire();
         defer self.lock.release();
-
         return self.unsafe_grow(nb_slab);
     }
 
     pub fn shrink(self: *Self) void {
         self.lock.acquire();
         defer self.lock.release();
-
         return self.unsafe_shrink();
     }
 
     pub fn available_chunks(self: *Self) usize {
         self.lock.acquire();
         defer self.lock.release();
-
         return self.unsafe_available_chunks();
     }
 
     pub fn prepare_alloc(self: *Self, count: usize) !void {
         self.lock.acquire();
         defer self.lock.release();
-
         return unsafe_prepare_alloc(count);
     }
 
     pub fn alloc_one(self: *Self) AllocError!*usize {
         self.lock.acquire();
         defer self.lock.release();
-
         return self.unsafe_alloc_one();
     }
 
-    pub fn free(self: *Self, ptr: *usize) (Slab.Error || BitMap.Error)!void {
+    pub fn free(self: *Self, ptr: *usize) Slab.Error!void {
         self.lock.acquire();
         defer self.lock.release();
-
         return self.unsafe_free(ptr);
     }
     //
     // End of thread safe methods
 
-    pub fn get_page_frame_descriptor(_: *Self, obj: *usize) *page_frame_descriptor {
-        const addr = std.mem.alignBackward(usize, @intFromPtr(obj), paging.page_size);
-        return mapping.get_page_frame_descriptor(@ptrFromInt(addr)) catch @panic("todo");
-    }
-
     pub fn has_obj(self: *Self, obj: *usize) bool {
-        const pfd = self.get_page_frame_descriptor(@ptrCast(obj));
-        return pfd.state.slab.cache == self;
+        const slab = Slab.resolve_head(@intFromPtr(obj)) catch return false;
+        return slab.cache() == self;
     }
 
     pub fn debug(self: *Self) void {
@@ -251,15 +270,15 @@ pub const Cache = struct {
         var nb_slab_full: usize = 0;
         var object_in_use: usize = 0;
 
-        var head: ?*Slab = self.slab_empty;
-        while (head) |slab| : (nb_slab_empty += 1) head = slab.header.next;
+        var head: ?Slab = self.slab_empty;
+        while (head) |slab| : (nb_slab_empty += 1) head = slab.next();
         head = self.slab_partial;
         while (head) |slab| : (nb_slab_partial += 1) {
-            head = slab.header.next;
-            object_in_use += slab.header.in_use;
+            head = slab.next();
+            object_in_use += slab.in_use();
         }
         head = self.slab_full;
-        while (head) |slab| : (nb_slab_full += 1) head = slab.header.next;
+        while (head) |slab| : (nb_slab_full += 1) head = slab.next();
 
         object_in_use += (nb_slab_full * self.obj_per_slab);
 
@@ -371,18 +390,18 @@ pub const GlobalCache = struct {
         defer self.lock.release();
 
         cache.shrink();
-        var lst: ?*Slab = cache.slab_full;
+        var lst: ?Slab = cache.slab_full;
 
         while (lst) |slab| {
-            lst = slab.header.next;
-            self.cache.reset_page_frame_descriptor(slab);
-            cache.page_allocator.free_pages(@ptrCast(@alignCast(slab)), cache.pages_per_slab);
+            lst = slab.next();
+            slab.reset_pfds(cache.pages_per_slab);
+            cache.page_allocator.free_pages(@ptrFromInt(slab.base_addr()), cache.pages_per_slab);
         }
         lst = cache.slab_partial;
         while (lst) |slab| {
-            lst = slab.header.next;
-            self.cache.reset_page_frame_descriptor(slab);
-            cache.page_allocator.free_pages(@ptrCast(@alignCast(slab)), cache.pages_per_slab);
+            lst = slab.next();
+            slab.reset_pfds(cache.pages_per_slab);
+            cache.page_allocator.free_pages(@ptrFromInt(slab.base_addr()), cache.pages_per_slab);
         }
         if (cache.prev) |prev| prev.next = cache.next else self.cache.next = cache.next;
         if (cache.next) |next| next.prev = cache.prev;

--- a/src/memory/object_allocators/slab/cache.zig
+++ b/src/memory/object_allocators/slab/cache.zig
@@ -111,9 +111,11 @@ pub const Cache = struct {
 
             for (0..self.obj_per_slab) |i| {
                 const obj_addr = base + (i * self.size_obj);
-                const obj_ptr: *u16 = @ptrFromInt(obj_addr);
-                obj_ptr.* = if (i + 1 < self.obj_per_slab) @truncate(i + 1) else Slab.FREE_SENTINEL;
+                const next_addr = if (i + 1 < self.obj_per_slab) base + ((i + 1) * self.size_obj) else 0;
+                const obj_ptr: *usize = @ptrFromInt(obj_addr);
+                obj_ptr.* = Slab.encode_ptr(obj_addr, next_addr);
             }
+            slab.set_next_free(base);
 
             self.link(slab, SlabState.Empty);
             self.nb_slab += 1;
@@ -155,22 +157,23 @@ pub const Cache = struct {
     fn unsafe_alloc_one(self: *Self) AllocError!*usize {
         const slab: ?Slab = if (self.slab_partial) |slab| slab else if (self.slab_empty) |slab| slab else null;
         if (slab) |s| {
-            const next = s.next_free();
-            if (next == Slab.FREE_SENTINEL) return Slab.Error.SlabFull;
-
-            const base = s.base_addr();
-            const obj_addr = base + (next * self.size_obj);
+            const obj_addr = s.next_free();
+            if (obj_addr == 0) return Slab.Error.SlabFull;
 
             const is_empty = s.in_use() == 0;
 
-            // Read the next free index from object's
-            const obj_ptr: *u16 = @ptrFromInt(obj_addr);
-            s.set_next_free(obj_ptr.*);
+            const obj_ptr: *usize = @ptrFromInt(obj_addr);
+            const new_next = Slab.decode_ptr(obj_addr, obj_ptr.*);
+            s.set_next_free(new_next);
             s.set_in_use(s.in_use() + 1);
+            // Overwrite the freelist encoding so that double-free detection in
+            // unsafe_free doesn't misread leftover freelist data as evidence the
+            // slot is already free.  ~0 decodes to an address outside any slab.
+            obj_ptr.* = Slab.encode_ptr(obj_addr, ~@as(usize, 0));
 
             if (is_empty) {
                 self.unsafe_move_slab(s, SlabState.Empty, SlabState.Partial);
-            } else if (s.next_free() == Slab.FREE_SENTINEL) {
+            } else if (s.next_free() == 0) {
                 self.unsafe_move_slab(s, SlabState.Partial, SlabState.Full);
             }
 
@@ -187,24 +190,26 @@ pub const Cache = struct {
 
         const cache = slab.cache();
         const base = slab.base_addr();
+        const slab_end = base + cache.size_obj * cache.obj_per_slab;
 
-        // Check if the object belongs to this cache
-        if (obj_addr < base or obj_addr >= base + (cache.size_obj * cache.obj_per_slab))
+        if (obj_addr < base or obj_addr >= slab_end)
             return Slab.Error.InvalidArgument;
         if ((obj_addr - base) % cache.size_obj != 0)
             return Slab.Error.InvalidArgument;
 
-        const index: u16 = @truncate((obj_addr - base) / cache.size_obj);
+        // Double-free detection: decode the stored value; if it decodes to 0
+        // (null sentinel) or a valid aligned object address in this slab, the
+        // slot is already in the freelist.
+        const obj_ptr: *usize = @ptrFromInt(obj_addr);
+        const decoded = Slab.decode_ptr(obj_addr, obj_ptr.*);
+        if (decoded == 0 or (decoded >= base and decoded < slab_end and (decoded - base) % cache.size_obj == 0))
+            return Slab.Error.DoubleFree;
 
-        // TODO: Double Free check
-
-        const was_full = slab.next_free() == Slab.FREE_SENTINEL;
+        const was_full = slab.next_free() == 0;
         slab.set_in_use(slab.in_use() - 1);
 
-        // Write the next free index to object's
-        const obj_ptr: *u16 = @ptrFromInt(obj_addr);
-        obj_ptr.* = slab.next_free();
-        slab.set_next_free(index);
+        obj_ptr.* = Slab.encode_ptr(obj_addr, slab.next_free());
+        slab.set_next_free(obj_addr);
 
         if (was_full) {
             cache.unsafe_move_slab(slab, SlabState.Full, SlabState.Partial);

--- a/src/memory/object_allocators/slab/cache.zig
+++ b/src/memory/object_allocators/slab/cache.zig
@@ -11,9 +11,6 @@ const Mutex = @import("../../../task/semaphore.zig").Mutex;
 const Slab = @import("slab.zig");
 const SlabState = @import("slab.zig").SlabState;
 
-// DEPRECATED
-const logger = std.log.scoped(.cache);
-
 const CACHE_NAME_LEN = 20;
 
 pub const Cache = struct {
@@ -34,6 +31,8 @@ pub const Cache = struct {
     obj_per_slab: u16 = 0,
     size_obj: usize = 0,
     align_obj: usize = 0,
+    debug: Slab.DebugFlags = .{},
+    slot_size: usize = 0, // slot_size = size_obj + optional redzone, rounded up to obj_align
     lock: Mutex = .{},
 
     pub fn init(
@@ -42,6 +41,7 @@ pub const Cache = struct {
         obj_size: usize,
         obj_align: usize,
         order: u5,
+        dbg: Slab.DebugFlags,
     ) Error!Cache {
         var new = Cache{
             .page_allocator = page_allocator,
@@ -50,8 +50,14 @@ pub const Cache = struct {
             .align_obj = obj_align,
         };
 
+        new.debug = dbg;
+        new.slot_size = if (dbg.redzone)
+            std.mem.alignForward(usize, new.size_obj + Slab.REDZONE_SIZE, obj_align)
+        else
+            new.size_obj;
+
         const total = paging.page_size * new.pages_per_slab;
-        new.obj_per_slab = @intCast(total / new.size_obj);
+        new.obj_per_slab = @intCast(total / new.slot_size);
 
         if (new.obj_per_slab == 0 or new.obj_per_slab >= (1 << 16))
             return Error.InitializationFailed;
@@ -102,21 +108,36 @@ pub const Cache = struct {
         self.unlink(slab, from);
         self.link(slab, to);
     }
-
     pub fn unsafe_grow(self: *Self, nb_slab: usize) PageAllocator.Error!void {
         for (0..nb_slab) |_| {
+            // Allocate pages for the new slab and initialize it
             const page = try self.page_allocator.alloc_pages(self.pages_per_slab);
             const slab: Slab = Slab.init_pfds(page, self);
             const base = slab.base_addr();
 
+            // Initialize the freelist for this slab, with optional debugging features
             for (0..self.obj_per_slab) |i| {
-                const obj_addr = base + (i * self.size_obj);
-                const next_addr = if (i + 1 < self.obj_per_slab) base + ((i + 1) * self.size_obj) else 0;
-                const obj_ptr: *usize = @ptrFromInt(obj_addr);
-                obj_ptr.* = Slab.encode_ptr(obj_addr, next_addr);
+                const slot_addr = base + (i * self.slot_size);
+                const next_addr = if (i + 1 < self.obj_per_slab) base + ((i + 1) * self.slot_size) else 0;
+                const slot: [*]u8 = @ptrFromInt(slot_addr);
+
+                // Poison the object body
+                if (self.debug.poison)
+                    @memset(slot[@sizeOf(usize)..self.size_obj], Slab.POISON_FREE);
+
+                // Right guard only: [size_obj .. slot_size] = REDZONE_MAGIC
+                if (self.debug.redzone)
+                    @memset(slot[self.size_obj..self.slot_size], Slab.REDZONE_MAGIC);
+
+                // The freelist is encoded in-place in the first bytes of the slot
+                const slot_ptr: *usize = @ptrFromInt(slot_addr);
+                slot_ptr.* = Slab.encode_ptr(slot_addr, next_addr);
             }
+
+            // Set the first freelist entry in the slab head PFD state
             slab.set_next_free(base);
 
+            // Link the new slab into the empty list and update cache metadata
             self.link(slab, SlabState.Empty);
             self.nb_slab += 1;
         }
@@ -155,67 +176,118 @@ pub const Cache = struct {
     }
 
     fn unsafe_alloc_one(self: *Self) AllocError!*usize {
-        const slab: ?Slab = if (self.slab_partial) |slab| slab else if (self.slab_empty) |slab| slab else null;
+        // Try to retrieve the first partial slab if any, otherwise the first empty slab
+        // If both are null, slab will be null and the function will try to grow the cache and retry allocation
+        const slab: ?Slab = self.slab_partial orelse self.slab_empty;
+
         if (slab) |s| {
-            const obj_addr = s.next_free();
-            if (obj_addr == 0) return Slab.Error.SlabFull;
+            const slot_addr = s.next_free();
+            if (slot_addr == 0) return Slab.Error.SlabFull;
 
             const is_empty = s.in_use() == 0;
 
-            const obj_ptr: *usize = @ptrFromInt(obj_addr);
-            const new_next = Slab.decode_ptr(obj_addr, obj_ptr.*);
+            // Decode the freelist entry at slot_addr to get the next free slot address,
+            // and update the slab metadata
+            const slot_ptr: *usize = @ptrFromInt(slot_addr);
+            const new_next = Slab.decode_ptr(slot_addr, slot_ptr.*);
             s.set_next_free(new_next);
             s.set_in_use(s.in_use() + 1);
-            // Overwrite the freelist encoding so that double-free detection in
-            // unsafe_free doesn't misread leftover freelist data as evidence the
-            // slot is already free.  ~0 decodes to an address outside any slab.
-            obj_ptr.* = Slab.encode_ptr(obj_addr, ~@as(usize, 0));
 
+            // Transition the slab to the appropriate state if needed
             if (is_empty) {
                 self.unsafe_move_slab(s, SlabState.Empty, SlabState.Partial);
             } else if (s.next_free() == 0) {
                 self.unsafe_move_slab(s, SlabState.Partial, SlabState.Full);
             }
 
-            return @ptrFromInt(obj_addr);
+            // Right-guard check: slot[size_obj..slot_size] must be REDZONE_MAGIC.  This detects
+            if (self.debug.redzone) try self.validate_redzone(slot_ptr);
+
+            // Check for use-after-free by verifying the object body is still poisoned
+            if (self.debug.poison) {
+                const slot = @as([*]u8, @ptrFromInt(slot_addr))[0..self.size_obj];
+                if (!std.mem.allEqual(u8, slot[@sizeOf(usize)..], Slab.POISON_FREE))
+                    return Slab.Error.SlabCorrupted;
+                @memset(slot, Slab.POISON_ALLOC);
+            }
+
+            // Overwrite the freelist encoding so that double-free detection in
+            // unsafe_free doesn't misread leftover freelist data as evidence the
+            // slot is already free.  ~0 decodes to an address outside any slab.
+            slot_ptr.* = Slab.encode_ptr(slot_addr, ~@as(usize, 0));
+
+            return slot_ptr;
         } else {
             try self.unsafe_grow(1);
             return self.unsafe_alloc_one();
         }
     }
 
-    pub fn unsafe_free(_: *Self, ptr: *usize) Slab.Error!void {
-        const obj_addr = @intFromPtr(ptr);
-        const slab = Slab.resolve_head(@ptrCast(ptr)) catch return Slab.Error.InvalidArgument;
+    pub fn unsafe_free(_: *Self, slot_ptr: *usize) Slab.Error!void {
+        const slot_addr = @intFromPtr(slot_ptr);
+        const slab = Slab.resolve_head(@ptrCast(slot_ptr)) catch return Slab.Error.InvalidArgument;
 
         const cache = slab.cache();
         const base = slab.base_addr();
-        const slab_end = base + cache.size_obj * cache.obj_per_slab;
+        const slab_end = base + cache.slot_size * cache.obj_per_slab;
 
-        if (obj_addr < base or obj_addr >= slab_end)
+        if (slot_addr < base or slot_addr + cache.slot_size > slab_end)
             return Slab.Error.InvalidArgument;
-        if ((obj_addr - base) % cache.size_obj != 0)
+        if ((slot_addr - base) % cache.slot_size != 0)
             return Slab.Error.InvalidArgument;
+
+        if (cache.debug.redzone) try cache.validate_redzone(slot_ptr);
 
         // Double-free detection: decode the stored value; if it decodes to 0
-        // (null sentinel) or a valid aligned object address in this slab, the
+        // (null sentinel) or a valid aligned slot address in this slab, the
         // slot is already in the freelist.
-        const obj_ptr: *usize = @ptrFromInt(obj_addr);
-        const decoded = Slab.decode_ptr(obj_addr, obj_ptr.*);
-        if (decoded == 0 or (decoded >= base and decoded < slab_end and (decoded - base) % cache.size_obj == 0))
+        const decoded = Slab.decode_ptr(slot_addr, slot_ptr.*);
+        if (decoded == 0 or (decoded >= base and decoded < slab_end and (decoded - base) % cache.slot_size == 0))
             return Slab.Error.DoubleFree;
+
+        if (cache.debug.sanity) try cache.validate_freelist(slab);
 
         const was_full = slab.next_free() == 0;
         slab.set_in_use(slab.in_use() - 1);
+        slot_ptr.* = Slab.encode_ptr(slot_addr, slab.next_free());
+        slab.set_next_free(slot_addr);
 
-        obj_ptr.* = Slab.encode_ptr(obj_addr, slab.next_free());
-        slab.set_next_free(obj_addr);
+        // Poison object body, skipping the freelist word just written at slot[0].
+        if (cache.debug.poison) {
+            const slot: [*]u8 = @ptrFromInt(slot_addr);
+            @memset(slot[@sizeOf(usize)..cache.size_obj], Slab.POISON_FREE);
+        }
 
+        // Transition the slab to the appropriate state if needed
         if (was_full) {
             cache.unsafe_move_slab(slab, SlabState.Full, SlabState.Partial);
         } else if (slab.in_use() == 0) {
             cache.unsafe_move_slab(slab, SlabState.Partial, SlabState.Empty);
         }
+    }
+
+    fn validate_freelist(self: *Cache, slab: Slab) Slab.Error!void {
+        var cursor = slab.next_free();
+        var count: u16 = 0;
+        const base = slab.base_addr();
+        const slab_end = base + self.slot_size * self.obj_per_slab;
+
+        // Walk the freelist and perform sanity checks
+        // Note: Maybe we could add some SlabError instead of only SlabCorrupted
+        while (cursor != 0) : (count += 1) {
+            if (count > self.obj_per_slab) return Slab.Error.SlabCorrupted; // cycle
+            if (cursor < base or cursor >= slab_end) return Slab.Error.SlabCorrupted; // oob address
+            if ((cursor - base) % self.slot_size != 0) return Slab.Error.SlabCorrupted; // misaligned address
+
+            const stored = @as(*usize, @ptrFromInt(cursor)).*;
+            cursor = Slab.decode_ptr(cursor, stored);
+        }
+    }
+
+    fn validate_redzone(self: *Cache, slot_ptr: *usize) Slab.Error!void {
+        const redzone = @as([*]u8, @ptrCast(@alignCast(slot_ptr)))[self.size_obj..self.slot_size];
+        if (!std.mem.allEqual(u8, redzone, Slab.REDZONE_MAGIC))
+            return Slab.Error.SlabCorrupted;
     }
 
     // Thread safe wrapper
@@ -269,7 +341,7 @@ pub const Cache = struct {
         return slab.cache() == self;
     }
 
-    pub fn debug(self: *Self) void {
+    pub fn dump(self: *Self) void {
         var nb_slab_empty: usize = 0;
         var nb_slab_partial: usize = 0;
         var nb_slab_full: usize = 0;
@@ -365,7 +437,7 @@ pub const GlobalCache = struct {
     lock: Mutex = Mutex{},
 
     pub fn init(allocator: PageAllocator) !GlobalCache {
-        return .{ .cache = try Cache.init("global", allocator, @sizeOf(Cache), @alignOf(Cache), 0) };
+        return .{ .cache = try Cache.init("global", allocator, @sizeOf(Cache), @alignOf(Cache), 0, .{}) };
     }
 
     pub fn create(
@@ -375,13 +447,14 @@ pub const GlobalCache = struct {
         obj_size: usize,
         obj_align: usize,
         order: u5,
+        dbg: Slab.DebugFlags,
     ) !*Cache {
         self.lock.acquire();
         defer self.lock.release();
 
         var cache: *Cache = @ptrCast(@alignCast(self.cache.alloc_one() catch |e| return e));
 
-        cache.* = try Cache.init(name, allocator, obj_size, obj_align, order);
+        cache.* = try Cache.init(name, allocator, obj_size, obj_align, order, dbg);
 
         cache.next = self.cache.next;
         if (self.cache.next) |next| next.prev = cache;
@@ -425,7 +498,7 @@ pub const GlobalCache = struct {
         printk("  \x1b[36mfull\x1b[0m", .{});
         printk("\n", .{});
         var node: ?*Cache = self.cache.next;
-        while (node) |n| : (node = n.next) n.debug();
-        self.cache.debug();
+        while (node) |n| : (node = n.next) n.dump();
+        self.cache.dump();
     }
 };

--- a/src/memory/object_allocators/slab/slab.zig
+++ b/src/memory/object_allocators/slab/slab.zig
@@ -1,138 +1,117 @@
-const printk = @import("../../../tty/tty.zig").printk;
-const Cache = @import("cache.zig").Cache;
-const BitMap = @import("../../../misc/bitmap.zig").BitMap;
-const Bit = @import("../../../misc/bitmap.zig").Bit;
 const std = @import("std");
+const paging = @import("../../paging.zig");
+const mapping = @import("../../mapping.zig");
 
-pub const SlabState = enum {
-    Empty,
-    Partial,
-    Full,
-};
+const Cache = @import("cache.zig").Cache;
+const pfd_t = paging.page_frame_descriptor;
+const Slab = @This();
 
-pub const SlabHeader = struct {
-    cache: *Cache = undefined,
-    next: ?*Slab = null,
-    prev: ?*Slab = null,
-    in_use: usize = 0,
-    next_free: ?u16 = 0,
-};
+pub const SlabState = enum { Empty, Partial, Full };
+pub const Error = error{ InvalidArgument, SlabFull, SlabCorrupted, DoubleFree };
 
-pub const Slab = struct {
-    const Self = @This();
+pub const FREE_SENTINEL: u16 = 0xFFFF;
 
-    pub const Error = error{ InvalidArgument, SlabFull, SlabCorrupted, DoubleFree };
+pfd: *pfd_t,
 
-    header: SlabHeader = SlabHeader{},
+pub fn from_pfd(pfd: *pfd_t) Slab {
+    return Slab{ .pfd = pfd };
+}
 
-    bitmap: BitMap = BitMap{},
-    data: []?u16 = undefined,
+pub fn from_page(ptr: paging.VirtualPagePtr) !Slab {
+    return Slab{ .pfd = Slab.get_pfd(ptr) };
+}
 
-    pub fn init(cache: *Cache, page: *usize) Slab {
-        var new = Slab{ .header = .{ .cache = cache } };
+pub fn resolve_head(ptr: paging.VirtualPtr) !Slab {
+    const pfd = mapping.get_page_frame_descriptor(
+        @ptrFromInt((std.mem.alignBackward(usize, @intFromPtr(ptr), paging.page_size))),
+    ) catch return error.InvalidArgument;
+    switch (pfd.state) {
+        .slab_head => return Slab{ .pfd = pfd },
+        .slab_tail => return Slab{ .pfd = pfd.state.slab_tail.head },
+        else => return error.InvalidArgument,
+    }
+}
 
-        const mem: [*]usize = @ptrFromInt(@intFromPtr(page) + @sizeOf(Slab));
-        new.bitmap = BitMap.init(mem, cache.obj_per_slab);
+// page frame descriptor lifecycle ---------------------------------------------
 
-        const start = std.mem.alignForward(
-            usize,
-            @intFromPtr(page) + @sizeOf(Slab) + new.bitmap.get_size(),
-            cache.align_obj,
-        );
-        new.data = @as([*]?u16, @ptrFromInt(start))[0 .. cache.obj_per_slab * (cache.size_obj / @sizeOf(usize))];
+/// Setup head and tail PFDs for a newly allocated slab.
+pub fn init_pfds(page_ptr: paging.VirtualPagePtr, c: *Cache) Slab {
+    const head_pfd: *pfd_t = Slab.get_pfd(page_ptr) catch unreachable;
+    head_pfd.state = .{
+        .slab_head = .{ .cache = c, .in_use = 0, .next_free = 0, .page = page_ptr },
+    };
 
-        for (0..cache.obj_per_slab) |i| {
-            new.data[i * (cache.size_obj / @sizeOf(usize))] =
-                if (i + 1 < cache.obj_per_slab) @truncate(i + 1) else null;
-        }
-        return new;
+    for (1..c.pages_per_slab) |i| {
+        const page_addr: paging.VirtualPagePtr = @ptrFromInt(@intFromPtr(page_ptr) + (i * paging.page_size));
+        const tail_pfd = Slab.get_pfd(page_addr) catch unreachable;
+        tail_pfd.state = .{ .slab_tail = .{ .head = head_pfd } };
     }
 
-    pub fn alloc_object(self: *Self) Error!*usize {
-        const next = self.header.next_free orelse return Error.SlabFull;
-        self.bitmap.set(next, Bit.Taken) catch return Error.SlabCorrupted;
+    return Slab{ .pfd = head_pfd };
+}
 
-        const index = next * (self.header.cache.size_obj / @sizeOf(usize));
-        switch (self.get_state()) {
-            .Empty => self.header.cache.unsafe_move_slab(self, .Partial),
-            .Partial => if (self.data[index] == null) self.header.cache.unsafe_move_slab(self, .Full),
-            .Full => unreachable,
-        }
-        self.header.next_free = self.data[index];
-        self.header.in_use += 1;
-        return @ptrCast(@alignCast(&self.data[index]));
+/// Reset all PFDs of this slab back to free state.
+pub fn reset_pfds(self: Slab, pages_per_slab: usize) void {
+    const base = self.base_addr();
+    for (0..pages_per_slab) |i| {
+        const page_addr: paging.VirtualPagePtr = @ptrFromInt(base + (i * paging.page_size));
+        const pfd = Slab.get_pfd(page_addr) catch unreachable;
+        pfd.state = .{ .other = 0 };
     }
+}
 
-    pub fn is_obj_in_slab(self: *Self, obj: *usize) bool {
-        const obj_addr = @intFromPtr(obj);
+// State management ------------------------------------------------------------
 
-        if (obj_addr < @intFromPtr(&self.data[0]) or obj_addr > @intFromPtr(&self.data[self.data.len - 1]))
-            return false;
-        if ((obj_addr - @intFromPtr(&self.data[0])) % self.header.cache.size_obj != 0)
-            return false;
-        return true;
-    }
+pub fn get_state(self: Slab) SlabState {
+    if (self.pfd.state.slab_head.in_use == 0) return SlabState.Empty;
+    if (self.pfd.state.slab_head.next_free == FREE_SENTINEL) return SlabState.Full;
+    return SlabState.Partial;
+}
 
-    pub fn free_object(self: *Self, obj: *usize) (Error || BitMap.Error)!void {
-        const obj_addr = @intFromPtr(obj);
+pub fn in_use(self: Slab) u16 {
+    return self.pfd.state.slab_head.in_use;
+}
 
-        if (!self.is_obj_in_slab(obj))
-            return Error.InvalidArgument;
+pub fn set_in_use(self: Slab, value: u16) void {
+    self.pfd.state.slab_head.in_use = value;
+}
 
-        const index: u16 = @truncate((obj_addr - @intFromPtr(&self.data[0])) / self.header.cache.size_obj);
-        if (self.bitmap.get(index) catch unreachable == .Free) return Error.DoubleFree;
-        self.bitmap.set(index, Bit.Free) catch unreachable;
-        switch (self.get_state()) {
-            .Empty => unreachable,
-            .Partial => if (self.header.in_use == 1) self.header.cache.unsafe_move_slab(self, .Empty),
-            .Full => self.header.cache.unsafe_move_slab(self, .Partial),
-        }
-        self.header.in_use -= 1;
-        self.data[index * (self.header.cache.size_obj / @sizeOf(usize))] = self.header.next_free;
-        self.header.next_free = index;
-    }
+pub fn base_addr(self: Slab) usize {
+    return @intFromPtr(self.pfd.state.slab_head.page);
+}
 
-    pub fn get_state(self: *Self) SlabState {
-        if (self.header.next_free == null) return .Full;
-        if (self.header.in_use == 0) return .Empty;
-        return .Partial;
-    }
+pub fn cache(self: Slab) *Cache {
+    return self.pfd.state.slab_head.cache;
+}
 
-    // TODO: Remove this method, for debugging purpose only...
-    pub fn debug(self: *Self) void {
-        printk("self: 0x{x}\n", .{@intFromPtr(self)});
-        printk("Slab Header:\n", .{});
-        inline for (@typeInfo(SlabHeader).Struct.fields) |field|
-            printk("  header.{s}: 0x{x} ({d} bytes)\n", .{
-                field.name,
-                @intFromPtr(&@field(self.header, field.name)),
-                @sizeOf(field.type),
-            });
+pub fn next_free(self: Slab) u16 {
+    return self.pfd.state.slab_head.next_free;
+}
 
-        printk("Bitmap:\n", .{});
-        inline for (@typeInfo(BitMap).Struct.fields) |field|
-            printk("  bitmap.{s}: 0x{x} ({d} bytes)\n", .{
-                field.name,
-                @intFromPtr(&@field(self.bitmap, field.name)),
-                @sizeOf(field.type),
-            });
+pub fn set_next_free(self: Slab, value: u16) void {
+    self.pfd.state.slab_head.next_free = value;
+}
 
-        printk("Data:\n", .{});
-        printk("  data: 0x{x} ({d} bytes)\n", .{ @intFromPtr(&self.data[0]), @sizeOf(@TypeOf(self.data)) });
+// Linked list management ------------------------------------------------------
 
-        printk("Values:\n", .{});
-        if (self.header.next_free) |next_free| printk("  next_free: {d}\n", .{
-            next_free,
-        }) else printk("  next_free: null\n", .{});
-        printk("  cache: 0x{x}\n", .{@intFromPtr(self.header.cache)});
-        if (self.header.next) |next| printk("  next: 0x{x}\n", .{
-            @intFromPtr(next),
-        }) else printk("  next: null\n", .{});
-        if (self.header.prev) |prev| printk("  prev: 0x{x}\n", .{
-            @intFromPtr(prev),
-        }) else printk("  prev: null\n", .{});
-        printk("  in_use: {d}\n", .{self.header.in_use});
-        printk("  state: {d}\n", .{self.get_state()});
-        printk("\n", .{});
-    }
-};
+pub fn next(self: Slab) ?Slab {
+    if (self.pfd.state.slab_head.next) |next_pfd| return Slab{ .pfd = next_pfd };
+    return null;
+}
+
+pub fn prev(self: Slab) ?Slab {
+    if (self.pfd.state.slab_head.prev) |prev_pfd| return Slab{ .pfd = prev_pfd };
+    return null;
+}
+
+pub fn set_next(self: Slab, slab: ?Slab) void {
+    self.pfd.state.slab_head.next = if (slab) |s| s.pfd else null;
+}
+
+pub fn set_prev(self: Slab, slab: ?Slab) void {
+    self.pfd.state.slab_head.prev = if (slab) |s| s.pfd else null;
+}
+
+pub fn get_pfd(ptr: paging.VirtualPagePtr) !*pfd_t {
+    return mapping.get_page_frame_descriptor(ptr) catch error.InvalidArgument;
+}

--- a/src/memory/object_allocators/slab/slab.zig
+++ b/src/memory/object_allocators/slab/slab.zig
@@ -9,7 +9,19 @@ const Slab = @This();
 pub const SlabState = enum { Empty, Partial, Full };
 pub const Error = error{ InvalidArgument, SlabFull, SlabCorrupted, DoubleFree };
 
-pub const FREE_SENTINEL: u16 = 0xFFFF;
+var secret: usize = 0;
+
+pub fn init_secret(s: usize) void {
+    secret = s;
+}
+
+pub fn encode_ptr(own_addr: usize, next_addr: usize) usize {
+    return own_addr ^ next_addr ^ secret;
+}
+
+pub fn decode_ptr(own_addr: usize, stored: usize) usize {
+    return own_addr ^ stored ^ secret;
+}
 
 pfd: *pfd_t,
 
@@ -64,7 +76,7 @@ pub fn reset_pfds(self: Slab, pages_per_slab: usize) void {
 
 pub fn get_state(self: Slab) SlabState {
     if (self.pfd.state.slab_head.in_use == 0) return SlabState.Empty;
-    if (self.pfd.state.slab_head.next_free == FREE_SENTINEL) return SlabState.Full;
+    if (self.pfd.state.slab_head.next_free == 0) return SlabState.Full;
     return SlabState.Partial;
 }
 
@@ -84,11 +96,11 @@ pub fn cache(self: Slab) *Cache {
     return self.pfd.state.slab_head.cache;
 }
 
-pub fn next_free(self: Slab) u16 {
+pub fn next_free(self: Slab) usize {
     return self.pfd.state.slab_head.next_free;
 }
 
-pub fn set_next_free(self: Slab, value: u16) void {
+pub fn set_next_free(self: Slab, value: usize) void {
     self.pfd.state.slab_head.next_free = value;
 }
 

--- a/src/memory/object_allocators/slab/slab.zig
+++ b/src/memory/object_allocators/slab/slab.zig
@@ -9,6 +9,26 @@ const Slab = @This();
 pub const SlabState = enum { Empty, Partial, Full };
 pub const Error = error{ InvalidArgument, SlabFull, SlabCorrupted, DoubleFree };
 
+pub const REDZONE_SIZE: usize = @sizeOf(usize);
+pub const REDZONE_MAGIC: u8 = 0xBB;
+pub const POISON_FREE: u8 = 0x6B;
+pub const POISON_ALLOC: u8 = 0xA5;
+
+pub const DebugFlags = packed struct(u8) {
+    /// Fill freed objects with POISON_FREE; on next alloc verify they weren't
+    /// written to (use-after-free detection). Fill allocated objects with
+    /// POISON_ALLOC so uninitialised-read is obvious.
+    poison: bool = false,
+    /// Insert REDZONE_SIZE guard bytes before and after each object. Checked
+    /// on every alloc and free to catch buffer overflows/underflows.
+    redzone: bool = false,
+    /// Walk the entire freelist on every alloc/free: count, bounds-check each
+    /// entry, and abort on cycle (count > obj_per_slab).
+    sanity: bool = false,
+
+    _: u5 = 0,
+};
+
 var secret: usize = 0;
 
 pub fn init_secret(s: usize) void {

--- a/src/memory/paging.zig
+++ b/src/memory/paging.zig
@@ -36,8 +36,8 @@ pub const slab_head_metadata = struct {
     /// number of objects currently allocated in this slab
     in_use: u16 = 0,
 
-    /// index of the first free object in this slab, or `FREE_SENTINEL` if none is free
-    next_free: u16 = 0,
+    /// address of the first free object in this slab, or 0 if none is free
+    next_free: usize = 0,
 };
 
 /// flags of a page frame

--- a/src/memory/paging.zig
+++ b/src/memory/paging.zig
@@ -7,17 +7,33 @@ pub const idx_t = usize;
 /// order type (for buddy allocation)
 pub const order_t = std.meta.Int(.unsigned, std.math.log2(@typeInfo(idx_t).int.bits));
 
+/// buddy block descriptor
+pub const buddy_metadata = struct {
+    next: ?*page_frame_descriptor = null,
+    prev: ?*page_frame_descriptor = null,
+};
+
+pub const slab_metadata = struct {
+    const Cache = @import("object_allocators/slab/cache.zig").Cache;
+    const Slab = @import("object_allocators/slab/slab.zig").Slab;
+
+    cache: *Cache = undefined,
+    slab: *Slab = undefined,
+};
+
 /// flags of a page frame
 pub const page_flags = packed struct {
     available: bool = false,
-    slab: bool = false,
 };
 
 /// page frame descriptor
 pub const page_frame_descriptor = struct {
     flags: page_flags,
-    next: ?*page_frame_descriptor = null,
-    prev: ?*page_frame_descriptor = null,
+    state: union(enum) {
+        buddy: buddy_metadata,
+        slab: slab_metadata,
+        other: u0,
+    } = .other,
 };
 
 pub const page_table_size = 1024;

--- a/src/memory/paging.zig
+++ b/src/memory/paging.zig
@@ -13,12 +13,31 @@ pub const buddy_metadata = struct {
     prev: ?*page_frame_descriptor = null,
 };
 
-pub const slab_metadata = struct {
-    const Cache = @import("object_allocators/slab/cache.zig").Cache;
-    const Slab = @import("object_allocators/slab/slab.zig").Slab;
+pub const slab_tail_metadata = struct {
+    /// if a slab needs more than one page,
+    /// the first page frame descriptor is the slab head and contains metadata about the slab,
+    /// while the others points to the head
+    head: *page_frame_descriptor = undefined,
+};
 
-    cache: *Cache = undefined,
-    slab: *Slab = undefined,
+pub const slab_head_metadata = struct {
+    const Cache = @import("object_allocators/slab/cache.zig").Cache;
+
+    /// pointer to the cache this slab belongs to
+    cache: *@import("object_allocators/slab/cache.zig").Cache = undefined,
+
+    /// virtual address of the slab's first page (needed to compute object addresses)
+    page: VirtualPagePtr = undefined,
+
+    /// previous slab head's page frame descriptor in empty/partial/full list of a given cache
+    prev: ?*page_frame_descriptor = null,
+    next: ?*page_frame_descriptor = null,
+
+    /// number of objects currently allocated in this slab
+    in_use: u16 = 0,
+
+    /// index of the first free object in this slab, or `FREE_SENTINEL` if none is free
+    next_free: u16 = 0,
 };
 
 /// flags of a page frame
@@ -31,7 +50,8 @@ pub const page_frame_descriptor = struct {
     flags: page_flags,
     state: union(enum) {
         buddy: buddy_metadata,
-        slab: slab_metadata,
+        slab_head: slab_head_metadata,
+        slab_tail: slab_tail_metadata,
         other: u0,
     } = .other,
 };

--- a/src/memory/paging.zig
+++ b/src/memory/paging.zig
@@ -36,7 +36,7 @@ pub const slab_head_metadata = struct {
     /// number of objects currently allocated in this slab
     in_use: u16 = 0,
 
-    /// address of the first free object in this slab, or 0 if none is free
+    /// address of the first free object in this slab, or 0 if none is free (Slab full)
     next_free: usize = 0,
 };
 

--- a/src/memory/region_set.zig
+++ b/src/memory/region_set.zig
@@ -53,6 +53,7 @@ pub const RegionSet = struct {
             @sizeOf(ListNode),
             @alignOf(ListNode),
             4,
+            .{},
         );
     }
 

--- a/src/memory/virtual_space.zig
+++ b/src/memory/virtual_space.zig
@@ -48,6 +48,7 @@ pub const VirtualSpace = struct {
             @sizeOf(Self),
             @alignOf(Self),
             5,
+            .{},
         );
     }
 

--- a/src/memory/virtual_space_allocator.zig
+++ b/src/memory/virtual_space_allocator.zig
@@ -44,6 +44,7 @@ pub const VirtualSpaceAllocator = struct {
                 @sizeOf(@This()),
                 @alignOf(@This()),
                 4,
+                .{},
             );
         }
     };

--- a/src/shell/default/builtins.zig
+++ b/src/shell/default/builtins.zig
@@ -209,10 +209,10 @@ pub fn cache_create(_: anytype, args: [][]u8) CmdError!void {
     const new_cache = globalCache.create(
         name,
         @import("../../memory.zig").directPageAllocator.page_allocator(),
-
         size,
         @truncate(order),
         @alignOf(usize),
+        .{},
     ) catch {
         printk("Failed to create cache\n", .{});
         return CmdError.OtherError;

--- a/src/task/signal.zig
+++ b/src/task/signal.zig
@@ -140,6 +140,7 @@ pub const SignalQueue = struct {
             @sizeOf(SignalNode),
             @alignOf(SignalNode),
             3,
+            .{},
         );
     }
 

--- a/src/task/task.zig
+++ b/src/task/task.zig
@@ -88,6 +88,7 @@ pub const TaskDescriptor = struct {
             @sizeOf(Self),
             @alignOf(Self),
             6,
+            .{},
         );
     }
 


### PR DESCRIPTION
### Summary

Transition from SLAB to SLUB-inspired allocator. All in-slab metadata is removed from page layouts and moved into the `page_frame_descriptor` via a tagged union, matching Linux's `struct page`/`struct slab` approach. The freelist switches from u16 indices to XOR-obfuscated pointers. Three optional debug flags are added for deeper corruption detection.

### Key changes:

**PFD metadata refactor**

  * Replaced flat `prev`/`next` fields in `page_frame_descriptor` with a tagged `state` union (`buddy`, `slab_head`, `slab_tail`, `other`).
  * `slab_head` holds cache pointer, linked-list prev/next PFD links, `in_use`, `next_free`, and the base page pointer.
  * `slab_tail` holds only a pointer back to the head PFD. Multi-page slabs use one head and N-1 tail descriptors.
  * Buddy allocator adapted to `state.buddy`.

**SLUB core**

  * `SlabHeader` and `BitMap` structures removed entirely from slab pages.
  * `slab.zig` introduced as a thin wrapper around PFD operations (`init_pfds`, `reset_pfds`, `base_addr`, state accessors, linked-list helpers).
  * `cache.zig` adapted to the new API; `obj_per_slab` simplified since there is no longer any in-slab overhead.
  * Fixed `unlink()` to take an explicit source state instead of re-reading it from the already-updated PFD, which caused double-linking between slab lists.

**XOR freelist hardening**

  * Replaced index-based freelist with pointer-based XOR-obfuscated freelist: each free slot stores `own_addr ^ next_addr ^ secret`.
  * `secret` is seeded from RDTSC at boot before any slab operation.
  * On `free()`, the stored value is decoded; if it resolves to `0` or a valid aligned slot address within the slab, the slot is flagged as already free (`DoubleFree` error).
  * An allocated-marker (`encode_ptr(addr, ~0)`) is written on alloc to prevent false positives from leftover freelist data in freshly allocated objects.

**Debug flags**

  * `DebugFlags` is a packed `u8` struct with three independent flags per cache: `poison`, `redzone`, `sanity`.
  * Poison: freed object body (excluding the freelist word) is filled with `POISON_FREE` (`0x6B`); on the next alloc the pattern is verified before the object is returned, detecting use-after-free writes. Allocated objects are then filled with `POISON_ALLOC` (`0xA5`) to expose uninitialised reads.
  * Redzone: `REDZONE_SIZE` guard bytes (`REDZONE_MAGIC = 0xBB`) are appended after each object. Checked on every alloc and free, catching buffer overflows. `slot_size` is widened accordingly, reducing `obj_per_slab`.
  * Sanity: on every `free()`, the full freelist is walked, with bounds and alignment checks on each entry; a counter exceeding `obj_per_slab` aborts with `SlabCorrupted`, catching cycles and complex double-free scenarios.

---
Closes: #233