### PR TITLE
ADD: Stack overflow detection & double fault handling

### DIFF
--- a/src/boot.zig
+++ b/src/boot.zig
@@ -8,7 +8,7 @@ const mapping = @import("memory/mapping.zig");
 const log = std.log;
 
 // Stack pages + 1 guard page if debug build (to catch stack overflows during boot phase)
-const STACK_PAGES: u32 = 8 + if (@import("build_options").optimize == .Debug) 1 else 0;
+const STACK_PAGES: u32 = 8;
 const STACK_SIZE: u32 = STACK_PAGES * paging.page_size;
 
 var stack: [STACK_SIZE]u8 align(4096) linksection(".bss") = undefined;
@@ -58,11 +58,9 @@ export fn _entry() linksection(".bootstrap_code") callconv(.naked) noreturn {
         \\ add $0xc0000000, %esp
         \\ call init
     );
-    while (true) {}
 }
 
-export fn init(eax: u32, ebx: u32) callconv(.c) void {
-    // Locks the scheduler (disables interrupts, and increments lock_depth)
+export fn init(eax: u32, ebx: u32) callconv(.c) noreturn {
     @import("task/scheduler.zig").enter_critical();
 
     if (eax == multiboot2_h.MULTIBOOT2_BOOTLOADER_MAGIC) {
@@ -71,40 +69,41 @@ export fn init(eax: u32, ebx: u32) callconv(.c) void {
 
     @import("trampoline.zig").clean();
 
+    init_hardware();
+    init_subsystems();
+    init_tasks(); // does not return, switches to idle task stack
+}
+
+/// Low-level CPU, chipset and memory initialization.
+fn init_hardware() void {
     @import("tty/tty.zig").init();
     log.info("Terminal initialized", .{});
 
     @import("gdt.zig").init();
-
     @import("drivers/pic/pic.zig").init();
 
-    // Sets up the IDT, and unlocks the scheduler (decrements lock_depth, and enables interrupts)
+    // Sets up the IDT, and unlocks the scheduler (decrements lock_depth, enables interrupts)
     @import("interrupts.zig").init();
 
     @import("memory.zig").init();
-
     @import("debug.zig").init();
 
     if (@import("build_options").optimize == .Debug) {
-        // Clear present bit on the first page of the boot stack to detect overflow
-        var raw: u32 = @bitCast(mapping.get_entry(boot_stack_guard_page));
-        raw &= ~@as(u32, 1);
-        mapping.set_entry(boot_stack_guard_page, @bitCast(raw));
+        mapping.clear_present(boot_stack_guard_page);
     }
 
     @import("drivers/tsc/tsc.zig").init();
-
     @import("timer.zig").init();
+}
 
+/// Drivers, kernel services and device initialization.
+fn init_subsystems() void {
     @import("drivers/ps2/ps2.zig").init();
-
     @import("tty/keyboard.zig").init();
-
     @import("./drivers/acpi/acpi.zig").init();
-
     @import("syscall.zig").init();
 
-    @import("task/signal.zig").SignalQueue.init_cache() catch @panic("Failed to initialized SignalQueue cache");
+    @import("task/signal.zig").SignalQueue.init_cache() catch @panic("Failed to initialize SignalQueue cache");
 
     // The ready_queue and wait_queue init functions are only here to setup their on_terminate task callbacks
     @import("task/ready_queue.zig").init();
@@ -117,13 +116,29 @@ export fn init(eax: u32, ebx: u32) callconv(.c) void {
 
     @import("drivers/block/ramdisk.zig").init();
     @import("drivers/block/ide_hd.zig").init();
+}
 
-    const idle_task = @import("task/task_set.zig").create_task() catch @panic("Failed to create idle task");
+/// Bootstrap the task system: create idle task, switch to its stack, spawn the kernel main task.
+/// Does not return, the boot stack is abandoned here.
+fn init_tasks() noreturn {
+    const task_set = @import("task/task_set.zig");
+    const scheduler = @import("task/scheduler.zig");
+    const gdt = @import("gdt.zig");
 
-    @import("task/scheduler.zig").init(idle_task);
+    const idle_task = task_set.create_task() catch @panic("Failed to create idle task");
+    scheduler.init(idle_task);
 
-    const kernel_task = @import("task/task_set.zig").create_task() catch @panic("Failed to create kernel task");
+    // Switch to the idle task's own stack. After this point the boot stack is dead.
+    gdt.tss.esp0 = idle_task.stack_top();
+    gdt.flush();
+    asm volatile (
+        \\ mov %[esp], %%esp
+        \\ mov %[esp], %%ebp
+        :
+        : [esp] "r" (idle_task.stack_top()),
+    );
 
+    const kernel_task = task_set.create_task() catch @panic("Failed to create kernel task");
     const main = if (!@import("build_options").ci) kernel.main else @import("ci.zig").main;
     kernel_task.spawn(main, undefined) catch @panic("Failed to spawn kernel main task");
 

--- a/src/boot.zig
+++ b/src/boot.zig
@@ -147,7 +147,10 @@ fn init_tasks() noreturn {
     }
 }
 
-pub fn panic(msg: []const u8, _: ?*builtin.StackTrace, _: ?usize) noreturn {
+pub fn panic(msg: []const u8, _: ?*builtin.StackTrace, ret_addr: ?usize) noreturn {
+    // Point the backtrace at the code that called @panic
+    const first_addr = ret_addr orelse @returnAddress();
+    @import("logger.zig").panic_trace_override = std.debug.StackIterator.init(first_addr, @frameAddress());
     log.err("{s}", .{msg});
     unreachable;
 }

--- a/src/boot.zig
+++ b/src/boot.zig
@@ -4,13 +4,20 @@ const multiboot2_h = @import("c_headers.zig").multiboot2_h;
 const multiboot = @import("multiboot.zig");
 const builtin = std.builtin;
 const paging = @import("memory/paging.zig");
+const mapping = @import("memory/mapping.zig");
 const log = std.log;
 
-const STACK_SIZE: u32 = 64 * 1024;
+// Stack pages + 1 guard page if debug build (to catch stack overflows during boot phase)
+const STACK_PAGES: u32 = 8 + if (@import("build_options").optimize == .Debug) 1 else 0;
+const STACK_SIZE: u32 = STACK_PAGES * paging.page_size;
 
 var stack: [STACK_SIZE]u8 align(4096) linksection(".bss") = undefined;
 
 export var stack_bottom: [*]u8 = @as([*]u8, @ptrCast(&stack)) + @sizeOf(@TypeOf(stack));
+
+// Address of the boot stack guard page (first page of the stack array).
+// Used by the double fault handler to detect stack overflow during boot phase.
+pub const boot_stack_guard_page: paging.VirtualPagePtr = @ptrCast(&stack);
 
 export var multiboot_header: multiboot.header_type align(4) linksection(".multiboot") = multiboot.get_header();
 
@@ -77,6 +84,13 @@ export fn init(eax: u32, ebx: u32) callconv(.c) void {
     @import("memory.zig").init();
 
     @import("debug.zig").init();
+
+    if (@import("build_options").optimize == .Debug) {
+        // Clear present bit on the first page of the boot stack to detect overflow
+        var raw: u32 = @bitCast(mapping.get_entry(boot_stack_guard_page));
+        raw &= ~@as(u32, 1);
+        mapping.set_entry(boot_stack_guard_page, @bitCast(raw));
+    }
 
     @import("drivers/tsc/tsc.zig").init();
 

--- a/src/boot.zig
+++ b/src/boot.zig
@@ -149,7 +149,10 @@ fn init_tasks() noreturn {
     }
 }
 
-pub fn panic(msg: []const u8, _: ?*builtin.StackTrace, _: ?usize) noreturn {
+pub fn panic(msg: []const u8, _: ?*builtin.StackTrace, ret_addr: ?usize) noreturn {
+    // Point the backtrace at the code that called @panic
+    const first_addr = ret_addr orelse @returnAddress();
+    @import("logger.zig").panic_trace_override = std.debug.StackIterator.init(first_addr, @frameAddress());
     log.err("{s}", .{msg});
     unreachable;
 }

--- a/src/boot.zig
+++ b/src/boot.zig
@@ -8,7 +8,7 @@ const mapping = @import("memory/mapping.zig");
 const log = std.log;
 
 // Stack pages + 1 guard page if debug build (to catch stack overflows during boot phase)
-const STACK_PAGES: u32 = 8 + if (@import("build_options").optimize == .Debug) 1 else 0;
+const STACK_PAGES: u32 = 8;
 const STACK_SIZE: u32 = STACK_PAGES * paging.page_size;
 
 var stack: [STACK_SIZE]u8 align(4096) linksection(".bss") = undefined;
@@ -58,11 +58,9 @@ export fn _entry() linksection(".bootstrap_code") callconv(.naked) noreturn {
         \\ add $0xc0000000, %esp
         \\ call init
     );
-    while (true) {}
 }
 
-export fn init(eax: u32, ebx: u32) callconv(.c) void {
-    // Locks the scheduler (disables interrupts, and increments lock_depth)
+export fn init(eax: u32, ebx: u32) callconv(.c) noreturn {
     @import("task/scheduler.zig").enter_critical();
 
     if (eax == multiboot2_h.MULTIBOOT2_BOOTLOADER_MAGIC) {
@@ -71,40 +69,41 @@ export fn init(eax: u32, ebx: u32) callconv(.c) void {
 
     @import("trampoline.zig").clean();
 
+    init_hardware();
+    init_subsystems();
+    init_tasks(); // does not return, switches to idle task stack
+}
+
+/// Low-level CPU, chipset and memory initialization.
+fn init_hardware() void {
     @import("tty/tty.zig").init();
     log.info("Terminal initialized", .{});
 
     @import("gdt.zig").init();
-
     @import("drivers/pic/pic.zig").init();
 
-    // Sets up the IDT, and unlocks the scheduler (decrements lock_depth, and enables interrupts)
+    // Sets up the IDT, and unlocks the scheduler (decrements lock_depth, enables interrupts)
     @import("interrupts.zig").init();
 
     @import("memory.zig").init();
-
     @import("debug.zig").init();
 
     if (@import("build_options").optimize == .Debug) {
-        // Clear present bit on the first page of the boot stack to detect overflow
-        var raw: u32 = @bitCast(mapping.get_entry(boot_stack_guard_page));
-        raw &= ~@as(u32, 1);
-        mapping.set_entry(boot_stack_guard_page, @bitCast(raw));
+        mapping.clear_present(boot_stack_guard_page);
     }
 
     @import("drivers/tsc/tsc.zig").init();
-
     @import("timer.zig").init();
+}
 
+/// Drivers, kernel services and device initialization.
+fn init_subsystems() void {
     @import("drivers/ps2/ps2.zig").init();
-
     @import("tty/keyboard.zig").init();
-
     @import("./drivers/acpi/acpi.zig").init();
-
     @import("syscall.zig").init();
 
-    @import("task/signal.zig").SignalQueue.init_cache() catch @panic("Failed to initialized SignalQueue cache");
+    @import("task/signal.zig").SignalQueue.init_cache() catch @panic("Failed to initialize SignalQueue cache");
 
     // The ready_queue and wait_queue init functions are only here to setup their on_terminate task callbacks
     @import("task/ready_queue.zig").init();
@@ -119,13 +118,29 @@ export fn init(eax: u32, ebx: u32) callconv(.c) void {
 
     @import("drivers/block/ramdisk.zig").init();
     @import("drivers/block/ide_hd.zig").init();
+}
 
-    const idle_task = @import("task/task_set.zig").create_task() catch @panic("Failed to create idle task");
+/// Bootstrap the task system: create idle task, switch to its stack, spawn the kernel main task.
+/// Does not return, the boot stack is abandoned here.
+fn init_tasks() noreturn {
+    const task_set = @import("task/task_set.zig");
+    const scheduler = @import("task/scheduler.zig");
+    const gdt = @import("gdt.zig");
 
-    @import("task/scheduler.zig").init(idle_task);
+    const idle_task = task_set.create_task() catch @panic("Failed to create idle task");
+    scheduler.init(idle_task);
 
-    const kernel_task = @import("task/task_set.zig").create_task() catch @panic("Failed to create kernel task");
+    // Switch to the idle task's own stack. After this point the boot stack is dead.
+    gdt.tss.esp0 = idle_task.stack_top();
+    gdt.flush();
+    asm volatile (
+        \\ mov %[esp], %%esp
+        \\ mov %[esp], %%ebp
+        :
+        : [esp] "r" (idle_task.stack_top()),
+    );
 
+    const kernel_task = task_set.create_task() catch @panic("Failed to create kernel task");
     const main = if (!@import("build_options").ci) kernel.main else @import("ci.zig").main;
     kernel_task.spawn(main, undefined) catch @panic("Failed to spawn kernel main task");
 

--- a/src/boot.zig
+++ b/src/boot.zig
@@ -90,8 +90,6 @@ export fn init(eax: u32, ebx: u32) callconv(.c) void {
 
     @import("syscall.zig").init();
 
-    @import("task/task.zig").TaskDescriptor.init_cache() catch @panic("Failed to initialized task_descriptor cache");
-
     @import("task/signal.zig").SignalQueue.init_cache() catch @panic("Failed to initialized SignalQueue cache");
 
     // The ready_queue and wait_queue init functions are only here to setup their on_terminate task callbacks

--- a/src/boot.zig
+++ b/src/boot.zig
@@ -130,17 +130,27 @@ fn init_tasks() noreturn {
     const idle_task = task_set.create_task() catch @panic("Failed to create idle task");
     scheduler.init(idle_task);
 
-    // Switch to the idle task's own stack. After this point the boot stack is dead.
+    // Switch to the idle task's own stack and hand over to idle_entry. The boot stack is
+    // dead past this point, so control must never come back to this frame: reloading esp
+    // and ebp invalidates everything the compiler holds relative to them, and any value it
+    // spilled before the switch would be read back from the wrong stack.
     gdt.tss.esp0 = idle_task.stack_top();
     gdt.flush();
     asm volatile (
         \\ mov %[esp], %%esp
         \\ mov %[esp], %%ebp
+        \\ call *%[entry]
         :
         : [esp] "r" (idle_task.stack_top()),
-    );
+          [entry] "r" (&idle_entry),
+        : .{ .memory = true });
+    unreachable;
+}
 
-    const kernel_task = task_set.create_task() catch @panic("Failed to create kernel task");
+/// Runs on the idle task's stack. Spawns the kernel main task, then becomes the idle loop.
+fn idle_entry() callconv(.c) noreturn {
+    const kernel_task = @import("task/task_set.zig").create_task() catch
+        @panic("Failed to create kernel task");
     const main = if (!@import("build_options").ci) kernel.main else @import("ci.zig").main;
     kernel_task.spawn(main, undefined) catch @panic("Failed to spawn kernel main task");
 

--- a/src/cpu.zig
+++ b/src/cpu.zig
@@ -110,6 +110,14 @@ pub inline fn reload_cr3() void {
     );
 }
 
+/// Invalidate a single TLB entry for the page containing the given address.
+pub inline fn invlpg(addr: usize) void {
+    asm volatile ("invlpg (%[addr])"
+        :
+        : [addr] "r" (addr),
+        : .{ .memory = true });
+}
+
 pub inline fn set_flag(flag: Cr0Flag) void {
     asm volatile (
         \\ mov %cr0, %eax

--- a/src/debug.zig
+++ b/src/debug.zig
@@ -152,8 +152,8 @@ fn dump_stack_trace_internal(writer: *std.io.Writer, stack_it: std.debug.StackIt
                 writer.print("file: {s}:{d}:{d}\n\n", .{ loc.file_name, loc.line, loc.column }) catch {};
             } else {
                 writer.print(
-                    "{s}:{d}:{d} \x1b[34m{s}\x1b[0m\n",
-                    .{ loc.file_name, loc.line, loc.column, sym.name },
+                    "{s}:{d}:{d}\n\x1b[1m0x{x}\x1b[0m - \x1b[34m{s}\x1b[0m\n\n",
+                    .{ loc.file_name, loc.line, loc.column, _addr, sym.name },
                 ) catch {};
             }
         } else {

--- a/src/gdt.zig
+++ b/src/gdt.zig
@@ -22,15 +22,15 @@ const access_byte_type = packed struct(u8) {
 const gdt_entry = struct {
     limit: u20,
     base: u32,
-    flags: u4,
-    access_byte: u8,
+    flags: flag_type,
+    access_byte: access_byte_type,
 };
 
 fn encode_gdt(entry: gdt_entry) u64 {
     return (((@as(u64, entry.base) >> 24) << 56) |
-        (@as(u64, entry.flags) << 52) |
+        (@as(u64, @intCast(@as(u4, @bitCast(entry.flags)))) << 52) |
         ((@as(u64, entry.limit) >> 16) << 48) |
-        (@as(u64, entry.access_byte) << 40) |
+        (@as(u64, @intCast(@as(u8, @bitCast(entry.access_byte)))) << 40) |
         ((@as(u64, entry.base) & 0xffffff) << 16) |
         (@as(u64, entry.limit) & 0xffff));
 }
@@ -130,6 +130,7 @@ var GDT = [_]u64{
         }),
     }),
     0, // TSS entry
+    0, // Double fault TSS entry
 };
 
 pub const GDTR = packed struct(u48) {
@@ -162,6 +163,17 @@ pub fn init() void {
         .flags = @bitCast(flag_type{ .size = true }),
     });
 
+    GDT[8] = encode_gdt(.{
+        .base = @intFromPtr(&double_fault_tss),
+        .limit = @sizeOf(@TypeOf(double_fault_tss)) - 1,
+        .access_byte = @bitCast(access_byte_type{
+            .present = true,
+            .executable = true,
+            .Accessed = true,
+        }),
+        .flags = @bitCast(flag_type{ .size = true }),
+    });
+
     // Initialize TSS
     tss.ss0 = .{ .index = 3, .table = .GDT, .privilege = cpu.PrivilegeLevel.Supervisor };
     tss.cs = .{ .index = 4, .table = .GDT, .privilege = cpu.PrivilegeLevel.User };
@@ -177,6 +189,18 @@ pub fn init() void {
     cpu.load_tss(.{ .index = 7, .table = .GDT, .privilege = cpu.PrivilegeLevel.Supervisor });
 
     logger.info("Gdt initialized", .{});
+}
+
+pub fn clear_busy_bit(selector: cpu.Selector) void {
+    const index = selector.index;
+    if (index >= GDT.len) {
+        logger.warn("Attempted to clear busy bit of selector with index {d}, but GDT only has {d} entries", .{
+            index, GDT.len,
+        });
+        return;
+    }
+
+    GDT[index] &= ~(@as(u64, 1) << 41); // Clear the Accessed bit, which is used as the busy bit for TSS descriptors
 }
 
 pub const Tss = extern struct {
@@ -220,3 +244,5 @@ pub const Tss = extern struct {
 };
 
 pub var tss: Tss align(4096) = .{};
+pub var double_fault_tss: Tss align(4096) = .{};
+pub var double_fault_stack: [4096 * 4]u8 align(4096) = undefined;

--- a/src/interrupts.zig
+++ b/src/interrupts.zig
@@ -200,6 +200,15 @@ fn get_id(obj: anytype) u8 {
     };
 }
 
+pub fn set_task_gate(id: anytype, tss_selector: cpu.Selector) void {
+    idt[get_id(id)] = InterruptDescriptor.init(
+        .{ .ptr = 0 },
+        .Task,
+        cpu.PrivilegeLevel.Supervisor,
+        tss_selector,
+    );
+}
+
 pub fn set_trap_gate(id: anytype, handler: Handler) void {
     idt[get_id(id)] = InterruptDescriptor.init(
         handler,

--- a/src/interrupts.zig
+++ b/src/interrupts.zig
@@ -342,12 +342,16 @@ pub fn default_handler(
     comptime t: enum { except, except_err, irq, interrupt },
 ) Handler {
     const handlers = struct {
-        pub fn exception(_: InterruptFrame) void {
+        pub fn exception(frame: InterruptFrame) void {
             const e = @as(Exceptions, @enumFromInt(id));
+            // Override the backtrace with the interrupted code's frame chain so the
+            // stack trace points at the faulting code, not at the interrupt handler.
+            @import("logger.zig").panic_trace_override = std.debug.StackIterator.init(null, frame.ebp);
             std.log.err("exception {d} ({s}) unhandled", .{ id, @tagName(e) });
         }
-        pub fn exception_err(_: InterruptFrame) void {
+        pub fn exception_err(frame: InterruptFrame) void {
             const e = @as(Exceptions, @enumFromInt(id));
+            @import("logger.zig").panic_trace_override = std.debug.StackIterator.init(null, frame.ebp);
             std.log.err("exception {d} ({s}) unhandled: 0x{x}", .{ id, @tagName(e), 0 });
         }
         pub fn irq(_: InterruptFrame) void {

--- a/src/logger.zig
+++ b/src/logger.zig
@@ -1,8 +1,13 @@
-const log = @import("std").log;
+const std = @import("std");
+const log = std.log;
 const tty = @import("tty/tty.zig");
 const colors = @import("colors");
 const screen_of_death = @import("screen_of_death.zig").screen_of_death;
 const scheduler = @import("task/scheduler.zig");
+
+/// Set this before triggering a panic to override the backtrace with
+/// the faulting code's stack instead of the panic/interrupt handler's own stack.
+pub var panic_trace_override: ?std.debug.StackIterator = null;
 
 pub fn kernel_log(
     comptime message_level: log.Level,
@@ -51,7 +56,12 @@ pub fn kernel_log(
             tty.get_tty().config.c_lflag.ECHO = false;
             tty.get_tty().config.c_lflag.ECHONL = false;
 
-            @import("debug.zig").dump_current_stack_trace() catch {};
+            if (panic_trace_override) |override| {
+                panic_trace_override = null;
+                @import("debug.zig").dump_stack_trace(override) catch {};
+            } else {
+                @import("debug.zig").dump_current_stack_trace() catch {};
+            }
 
             while (true) {
                 @import("cpu.zig").halt();

--- a/src/memory.zig
+++ b/src/memory.zig
@@ -118,6 +118,7 @@ fn init_kernel_vm() void {
 
     logger.debug("\tActivating kernel virtual space...", .{});
     kernel_virtual_space.transfer();
+    @import("memory/page_fault.zig").update_double_fault_cr3();
     kernel_virtual_space.fill_page_tables(paging.kernel_page_tables / paging.page_size, 256, true) catch {
         @panic("not enough space to boot");
     };

--- a/src/memory/mapping.zig
+++ b/src/memory/mapping.zig
@@ -64,6 +64,26 @@ pub fn get_entry(virtual: paging.VirtualPagePtr) paging.TableEntry {
     return table[virtualStruct.table_index];
 }
 
+/// Clear the present bit of a page table entry (e.g. to set up a guard page).
+pub fn clear_present(virtual: paging.VirtualPagePtr) void {
+    const virtualStruct: paging.VirtualPtrStruct = @bitCast(@intFromPtr(virtual));
+    const table = get_table_ptr(virtualStruct.dir_index);
+    var raw: u32 = @bitCast(table[virtualStruct.table_index]);
+    raw &= ~@as(u32, 1);
+    table[virtualStruct.table_index] = @bitCast(raw);
+    cpu.invlpg(@intFromPtr(virtual));
+}
+
+/// Restore the present bit of a page table entry (e.g. before freeing a guard page).
+pub fn set_present(virtual: paging.VirtualPagePtr) void {
+    const virtualStruct: paging.VirtualPtrStruct = @bitCast(@intFromPtr(virtual));
+    const table = get_table_ptr(virtualStruct.dir_index);
+    var raw: u32 = @bitCast(table[virtualStruct.table_index]);
+    raw |= 1;
+    table[virtualStruct.table_index] = @bitCast(raw);
+    cpu.invlpg(@intFromPtr(virtual));
+}
+
 pub fn transfer(new: *align(4096) Directory) void {
     cpu.set_cr3(get_physical_ptr(@ptrCast(new)) catch unreachable);
 }

--- a/src/memory/page_fault.zig
+++ b/src/memory/page_fault.zig
@@ -114,10 +114,16 @@ fn user_page_fault(fault: PageFault) void {
 }
 
 fn page_fault_handler(frame: InterruptFrame) void {
+    // Set the override early so any panic or default-scope log.err that
+    // propagates from the fault handling chain (kernel_page_fault, user_page_fault,
+    // local panic(), etc.) shows the faulting code's backtrace, not the handler's.
+    @import("../logger.zig").panic_trace_override = std.debug.StackIterator.init(null, frame.ebp);
+
     const fault = page_fault_from_i386(frame);
 
     if (fault.present != mapping.is_page_present(fault.entry)) {
-        @panic("page fault on a present page! (entry is not invalidated)");
+        std.log.err("page fault on a present page! (entry is not invalidated)", .{});
+        unreachable;
     }
 
     switch (fault.mode) {
@@ -143,6 +149,7 @@ fn panic(fault: PageFault) void {
             @import("../task/scheduler.zig").get_current_task().pid,
         },
     );
+    unreachable;
 }
 
 pub fn set_handler() void {
@@ -229,9 +236,16 @@ fn handle_double_fault() noreturn {
         std.mem.alignBackward(usize, fault_addr, paging.page_size),
     );
 
+    // Point the backtrace at the faulting task's context saved into gdt.tss
+    // by the CPU during the hardware task switch that delivered the double fault.
+    @import("../logger.zig").panic_trace_override = std.debug.StackIterator.init(null, gdt.tss.ebp);
+
     if (!scheduler.is_initialized()) {
         force_unlock_allocator_mutexes();
-        @panic("early boot double fault (probably stack overflow)");
+        std.log.err("early boot double fault (probably stack overflow, faulting esp: 0x{x})", .{
+            faulting_esp,
+        });
+        unreachable;
     }
 
     scheduler.enter_critical();
@@ -256,5 +270,6 @@ fn handle_double_fault() noreturn {
         unreachable;
     }
 
-    @panic("double fault");
+    std.log.err("double fault", .{});
+    unreachable;
 }

--- a/src/memory/page_fault.zig
+++ b/src/memory/page_fault.zig
@@ -3,6 +3,7 @@ const paging = @import("paging.zig");
 const regions = @import("regions.zig");
 const Region = regions.Region;
 const cpu = @import("../cpu.zig");
+const gdt = @import("../gdt.zig");
 const mapping = @import("mapping.zig");
 const scheduler = @import("../task/scheduler.zig");
 const InterruptFrame = @import("../interrupts.zig").InterruptFrame;
@@ -147,4 +148,113 @@ fn panic(fault: PageFault) void {
 pub fn set_handler() void {
     const interrupts = @import("../interrupts.zig");
     interrupts.set_intr_gate(.PageFault, interrupts.Handler.create(&page_fault_handler, true));
+
+    if (@import("build_options").optimize == .Debug) {
+        const kernel_data = cpu.Selector{ .index = 2, .table = .GDT, .privilege = .Supervisor };
+        const kernel_code = cpu.Selector{ .index = 1, .table = .GDT, .privilege = .Supervisor };
+
+        gdt.double_fault_tss.esp = @intFromPtr(&gdt.double_fault_stack) + gdt.double_fault_stack.len;
+        gdt.double_fault_tss.ss = kernel_data;
+        gdt.double_fault_tss.ds = kernel_data;
+        gdt.double_fault_tss.es = kernel_data;
+        gdt.double_fault_tss.cs = kernel_code;
+        gdt.double_fault_tss.eip = @intFromPtr(&double_fault_entry);
+        gdt.double_fault_tss.eflags = @bitCast(cpu.EFlags{ .interrupt_enable = false });
+
+        // Zig debug mode passes a hidden "return address" pointer via ECX through
+        // the call chain. The hardware task switch loads ECX from df_tss.ecx (default 0).
+        // Point ECX to df_tss.eip so that *ECX is a valid code address, preventing
+        // NULL dereferences in logger/format code.
+        gdt.double_fault_tss.ecx = @intFromPtr(&gdt.double_fault_tss.eip);
+        // NOTE: cr3 is set later by update_double_fault_cr3() after the kernel virtual
+        // space is transferred, since transfer() changes CR3.
+
+        const double_fault_selector = cpu.Selector{ .index = 8, .table = .GDT, .privilege = .Supervisor };
+        @import("../interrupts.zig").set_task_gate(.DoubleFault, double_fault_selector);
+    }
+}
+
+/// Must be called after the kernel page directory is active (after transfer()).
+pub fn update_double_fault_cr3() void {
+    if (@import("build_options").optimize == .Debug) {
+        gdt.double_fault_tss.cr3 = cpu.get_cr3();
+    }
+}
+
+fn double_fault_entry() callconv(.naked) noreturn {
+    asm volatile (
+    // Clear NT flag (bit 14) so IRET doesn't reverse the task switch
+        \\ pushfd
+        \\ andl $0xffffbfff, (%%esp)
+        \\ popfd
+        \\ jmp *%[handler]
+        :
+        : [handler] "r" (&handle_double_fault),
+    );
+}
+
+/// Force-unlock all mutexes in the allocation chain used by debug backtraces.
+/// Only safe in a terminal panic context (double fault) where we never resume.
+fn force_unlock_allocator_mutexes() void {
+    const memory = @import("../memory.zig");
+    // PageFrameAllocator mutex
+    memory.pageFrameAllocator.lock.count = 0;
+    // Kernel virtual space mutex
+    memory.kernel_virtual_space.lock.count = 0;
+    // Global slab cache mutex
+    memory.globalCache.lock.count = 0;
+    memory.globalCache.cache.lock.count = 0;
+}
+
+fn handle_double_fault() noreturn {
+    // Clear the busy bit of the TSS descriptor to prevent the CPU from refusing to switch
+    gdt.clear_busy_bit(.{ .index = 8 });
+    gdt.clear_busy_bit(.{ .index = 7 });
+
+    // Restore TR to the main TSS (index 7).
+    // The scheduler sets gdt.tss.esp 0, if TR pointed to double_fault_tss,
+    // that field would never be read by the CPU on privilege transitions.
+    // Also when TR=df_tss, a subsequent double fault can't switch
+    // to df_tss (because it's the current task and busy) → triple fault.
+    cpu.load_tss(.{ .index = 7, .table = .GDT, .privilege = .Supervisor });
+
+    // The hardware task switch saved the faulting task's context into the gdt.tss.
+    const faulting_esp = gdt.tss.esp;
+    const faulting_page: paging.VirtualPagePtr = @ptrFromInt(
+        std.mem.alignBackward(usize, faulting_esp, paging.page_size),
+    );
+
+    if (!scheduler.is_initialized()) {
+        force_unlock_allocator_mutexes();
+        @panic("early boot double fault (probably stack overflow)");
+    }
+
+    scheduler.enter_critical();
+
+    const faulting_task = scheduler.get_current_task();
+    if (faulting_task.is_guard_page(faulting_page)) {
+        // terminate the faulting task
+        faulting_task.state = .Zombie;
+        faulting_task.update_status(.{
+            .transition = .Terminated,
+            .signaled = true,
+            .siginfo = .{
+                .si_signo = .{ .valid = .SIGSEGV },
+                .si_code = .SI_USER,
+                .si_pid = 0,
+                .si_addr = @ptrCast(faulting_page),
+            },
+        });
+        std.log.warn("stack overflow: task {d} (guard: 0x{x}), terminating task", .{
+            faulting_task.pid,
+            @intFromPtr(faulting_page),
+        });
+        for (@import("../task/task.zig").on_terminate_callback.items) |callback| {
+            callback(faulting_task);
+        }
+        scheduler.schedule();
+        unreachable;
+    }
+
+    @panic("double fault");
 }

--- a/src/memory/page_fault.zig
+++ b/src/memory/page_fault.zig
@@ -220,8 +220,13 @@ fn handle_double_fault() noreturn {
 
     // The hardware task switch saved the faulting task's context into the gdt.tss.
     const faulting_esp = gdt.tss.esp;
+    // On x86, interrupt delivery pushes the frame by decrementing ESP before writing.
+    // If ESP is exactly page-aligned, the CPU decrements it into the page below before
+    // the write fails, but the saved ESP is the pre-decrement value. Subtract 1 so that
+    // alignBackward resolves to the page that was actually accessed (the guard page).
+    const fault_addr = if (faulting_esp & (paging.page_size - 1) == 0) faulting_esp - 1 else faulting_esp;
     const faulting_page: paging.VirtualPagePtr = @ptrFromInt(
-        std.mem.alignBackward(usize, faulting_esp, paging.page_size),
+        std.mem.alignBackward(usize, fault_addr, paging.page_size),
     );
 
     if (!scheduler.is_initialized()) {
@@ -233,25 +238,20 @@ fn handle_double_fault() noreturn {
 
     const faulting_task = scheduler.get_current_task();
     if (faulting_task.is_guard_page(faulting_page)) {
-        // terminate the faulting task
-        faulting_task.state = .Zombie;
-        faulting_task.update_status(.{
-            .transition = .Terminated,
-            .signaled = true,
-            .siginfo = .{
-                .si_signo = .{ .valid = .SIGSEGV },
-                .si_code = .SI_USER,
-                .si_pid = 0,
-                .si_addr = @ptrCast(faulting_page),
-            },
-        });
         std.log.warn("stack overflow: task {d} (guard: 0x{x}), terminating task", .{
             faulting_task.pid,
             @intFromPtr(faulting_page),
         });
-        for (@import("../task/task.zig").on_terminate_callback.items) |callback| {
-            callback(faulting_task);
-        }
+        faulting_task.terminate(.{
+            .transition = .Terminated,
+            .signaled = true,
+            .siginfo = .{
+                .si_signo = .{ .valid = .SIGSEGV },
+                .si_code = .SEGV_MAPERR,
+                .si_pid = 0,
+                .si_addr = @ptrCast(faulting_page),
+            },
+        });
         scheduler.schedule();
         unreachable;
     }

--- a/src/task/task.zig
+++ b/src/task/task.zig
@@ -17,7 +17,7 @@ const StatusStack = @import("status_stack.zig").StatusStack;
 const logger = std.log.scoped(.task);
 const Errno = @import("../errno.zig").Errno;
 
-const STACK_TOTAL_PAGES = 16 + (if (@import("build_options").optimize == .Debug) 1 else 0);
+const STACK_TOTAL_PAGES = 16;
 const STACK_SIZE = STACK_TOTAL_PAGES * paging.page_size;
 
 const callback_allocator = @import("../memory.zig").smallAlloc.allocator();
@@ -90,10 +90,7 @@ pub const TaskDescriptor = struct {
         const base = try page_alloc.alloc_pages(STACK_TOTAL_PAGES);
 
         if (is_debug) {
-            // Clear present bit on the guard page (first page) to catch stack overflow.
-            var raw: u32 = @bitCast(mapping.get_entry(base));
-            raw &= ~@as(u32, 1);
-            mapping.set_entry(base, @bitCast(raw));
+            mapping.clear_present(base);
         }
 
         return @ptrFromInt(@intFromPtr(base) + STACK_SIZE - @sizeOf(Self));
@@ -104,10 +101,7 @@ pub const TaskDescriptor = struct {
         const base: paging.VirtualPagePtr = @ptrFromInt(@intFromPtr(self) - STACK_SIZE + @sizeOf(Self));
 
         if (is_debug) {
-            // Restore present bit on the guard page (first page) before freeing
-            var raw: u32 = @bitCast(mapping.get_entry(base));
-            raw |= 1;
-            mapping.set_entry(base, @bitCast(raw));
+            mapping.set_present(base);
         }
 
         page_alloc.free_pages(base, STACK_TOTAL_PAGES);
@@ -118,6 +112,17 @@ pub const TaskDescriptor = struct {
         if (!is_debug) return false;
         const base = @intFromPtr(self) + @sizeOf(Self) - STACK_SIZE;
         return @intFromPtr(page) == base;
+    }
+
+    /// Terminate this task: mark as Zombie, notify parent, and fire on_terminate callbacks.
+    /// The caller is responsible for calling scheduler.schedule() afterwards if needed.
+    pub fn terminate(self: *Self, status: @import("status_informations.zig").Status) void {
+        if (self.state == .Ready)
+            ready_queue.remove(self);
+        self.state = .Zombie;
+        self.update_status(status);
+        for (on_terminate_callback.items) |callback|
+            callback(self);
     }
 
     /// Return stack top (initial esp value). Stack grows downwards from here.
@@ -228,16 +233,11 @@ pub const TaskDescriptor = struct {
     fn handle_default_action(self: *Self, sig: signal.siginfo_t) void {
         switch (self.signalManager.get_defaultAction(sig.si_signo.unwrap())) {
             .Ignore => {},
-            .Terminate => {
-                if (self.state == .Ready)
-                    ready_queue.remove(self);
-                self.state = .Zombie;
-                self.update_status(.{
-                    .transition = .Terminated,
-                    .signaled = true,
-                    .siginfo = sig,
-                });
-            },
+            .Terminate => self.terminate(.{
+                .transition = .Terminated,
+                .signaled = true,
+                .siginfo = sig,
+            }),
             .Stop => if (self.state == .Running or self.state == .Ready) {
                 if (self.state == .Ready)
                     ready_queue.remove(self);
@@ -436,18 +436,13 @@ pub fn getpid() TaskDescriptor.Pid {
 pub fn exit(code: u8) noreturn {
     scheduler.enter_critical();
 
-    const task = scheduler.get_current_task();
-    task.state = .Zombie;
-    task.update_status(.{
+    scheduler.get_current_task().terminate(.{
         .transition = .Terminated,
         .signaled = false,
         .siginfo = .{
             .si_status = code,
         },
     });
-
-    for (on_terminate_callback.items) |callback|
-        callback(task);
 
     scheduler.schedule();
     unreachable;

--- a/src/task/task.zig
+++ b/src/task/task.zig
@@ -17,7 +17,7 @@ const StatusStack = @import("status_stack.zig").StatusStack;
 const logger = std.log.scoped(.task);
 const Errno = @import("../errno.zig").Errno;
 
-const STACK_TOTAL_PAGES = 16;
+const STACK_TOTAL_PAGES = 16 + (if (@import("build_options").optimize == .Debug) 1 else 0);
 const STACK_SIZE = STACK_TOTAL_PAGES * paging.page_size;
 
 const callback_allocator = @import("../memory.zig").smallAlloc.allocator();
@@ -81,20 +81,43 @@ pub const TaskDescriptor = struct {
     pub const Pid = i32;
     pub const Self = @This();
 
+    const is_debug = @import("build_options").optimize == .Debug;
+
     /// Allocate pages and return a pointer to the TaskDescriptor located at the end of the allocation.
     /// The stack is the memory region before self.
     pub fn alloc() !*Self {
         const page_alloc = memory.directPageAllocator.page_allocator();
         const base = try page_alloc.alloc_pages(STACK_TOTAL_PAGES);
 
+        if (is_debug) {
+            // Clear present bit on the guard page (first page) to catch stack overflow.
+            var raw: u32 = @bitCast(mapping.get_entry(base));
+            raw &= ~@as(u32, 1);
+            mapping.set_entry(base, @bitCast(raw));
+        }
+
         return @ptrFromInt(@intFromPtr(base) + STACK_SIZE - @sizeOf(Self));
     }
 
     pub fn dealloc(self: *Self) void {
         const page_alloc = memory.directPageAllocator.page_allocator();
-        const base_addr = @intFromPtr(self) - STACK_SIZE + @sizeOf(Self);
+        const base: paging.VirtualPagePtr = @ptrFromInt(@intFromPtr(self) - STACK_SIZE + @sizeOf(Self));
 
-        page_alloc.free_pages(@ptrFromInt(base_addr), STACK_TOTAL_PAGES);
+        if (is_debug) {
+            // Restore present bit on the guard page (first page) before freeing
+            var raw: u32 = @bitCast(mapping.get_entry(base));
+            raw |= 1;
+            mapping.set_entry(base, @bitCast(raw));
+        }
+
+        page_alloc.free_pages(base, STACK_TOTAL_PAGES);
+    }
+
+    /// Check if a faulting page is this task's guard page (debug only).
+    pub fn is_guard_page(self: *Self, page: paging.VirtualPagePtr) bool {
+        if (!is_debug) return false;
+        const base = @intFromPtr(self) + @sizeOf(Self) - STACK_SIZE;
+        return @intFromPtr(page) == base;
     }
 
     /// Return stack top (initial esp value). Stack grows downwards from here.

--- a/src/task/task.zig
+++ b/src/task/task.zig
@@ -8,7 +8,7 @@ const gdt = @import("../gdt.zig");
 const task_set = @import("task_set.zig");
 const signal = @import("signal.zig");
 const ucontext = @import("ucontext.zig");
-const Cache = @import("../memory/object_allocators/slab/cache.zig").Cache;
+const mapping = @import("../memory/mapping.zig");
 const scheduler = @import("scheduler.zig");
 const ready_queue = @import("ready_queue.zig");
 const wait_queue = @import("wait_queue.zig");
@@ -16,6 +16,9 @@ const status_informations = @import("status_informations.zig");
 const StatusStack = @import("status_stack.zig").StatusStack;
 const logger = std.log.scoped(.task);
 const Errno = @import("../errno.zig").Errno;
+
+const STACK_TOTAL_PAGES = 16;
+const STACK_SIZE = STACK_TOTAL_PAGES * paging.page_size;
 
 const callback_allocator = @import("../memory.zig").smallAlloc.allocator();
 const Callback = *const fn (*TaskDescriptor) void;
@@ -38,7 +41,6 @@ pub fn remove_on_terminate_callback(callback: *const fn (*TaskDescriptor) void) 
 
 pub const TaskDescriptor = struct {
     // todo: define the appropriate size for a kernelspace stack or get this value from config
-    stack: [64 * 1024]u8 align(4096) = undefined,
     pid: Pid,
     pgid: Pid,
 
@@ -79,17 +81,25 @@ pub const TaskDescriptor = struct {
     pub const Pid = i32;
     pub const Self = @This();
 
-    pub var cache: *Cache = undefined;
+    /// Allocate pages and return a pointer to the TaskDescriptor located at the end of the allocation.
+    /// The stack is the memory region before self.
+    pub fn alloc() !*Self {
+        const page_alloc = memory.directPageAllocator.page_allocator();
+        const base = try page_alloc.alloc_pages(STACK_TOTAL_PAGES);
 
-    pub fn init_cache() !void {
-        cache = try memory.globalCache.create(
-            "task_descriptor",
-            memory.directPageAllocator.page_allocator(),
-            @sizeOf(Self),
-            @alignOf(Self),
-            6,
-            .{},
-        );
+        return @ptrFromInt(@intFromPtr(base) + STACK_SIZE - @sizeOf(Self));
+    }
+
+    pub fn dealloc(self: *Self) void {
+        const page_alloc = memory.directPageAllocator.page_allocator();
+        const base_addr = @intFromPtr(self) - STACK_SIZE + @sizeOf(Self);
+
+        page_alloc.free_pages(@ptrFromInt(base_addr), STACK_TOTAL_PAGES);
+    }
+
+    /// Return stack top (initial esp value). Stack grows downwards from here.
+    pub fn stack_top(self: *Self) usize {
+        return @intFromPtr(self);
     }
 
     pub fn deinit(self: *Self) void {
@@ -323,7 +333,7 @@ pub const TaskDescriptor = struct {
             : [function] "r" (function),
               [data] "r" (data),
               [is_parent] "r" (&is_parent),
-              [new_stack] "r" (@as(usize, @intFromPtr(&self.stack)) + self.stack.len),
+              [new_stack] "r" (self.stack_top()),
               [self] "r" (self),
               [tmp] "q" (0),
         );
@@ -334,7 +344,7 @@ pub const TaskDescriptor = struct {
         const function: *const fn (usize) u8 = @ptrCast(function_ptr);
         self.state = .Running;
         scheduler.set_current_task(self);
-        gdt.tss.esp0 = @as(usize, @intFromPtr(&self.stack)) + self.stack.len;
+        gdt.tss.esp0 = self.stack_top();
         gdt.flush();
         scheduler.exit_critical();
         exit(function(data));
@@ -376,7 +386,7 @@ pub fn switch_to_task(prev: *TaskDescriptor, next: *TaskDescriptor) void {
     }
     next.state = .Running;
 
-    gdt.tss.esp0 = @as(usize, @intFromPtr(&next.stack)) + next.stack.len;
+    gdt.tss.esp0 = next.stack_top();
     gdt.flush();
 
     return switch_to_task_opts(prev, next);

--- a/src/task/task_set.zig
+++ b/src/task/task_set.zig
@@ -13,7 +13,7 @@ pub fn create_task() !*TaskDescriptor {
     defer scheduler.exit_critical();
 
     const pid = next_pid() orelse return error.TooMuchProcesses;
-    const new_task = try TaskDescriptor.cache.allocator().create(TaskDescriptor);
+    const new_task = try TaskDescriptor.alloc();
     const parent = scheduler.get_current_task();
     if (pid == 0) {
         new_task.* = .{ .pid = pid, .pgid = pid, .parent = null, .state = .Running };
@@ -55,5 +55,5 @@ pub fn destroy_task(pid: TaskDescriptor.Pid) !void {
     descriptor.deinit();
     list[index] = null;
     count -= 1;
-    TaskDescriptor.cache.allocator().destroy(descriptor);
+    descriptor.dealloc();
 }


### PR DESCRIPTION
### Summary

This Pull Request introduces guard-page-based stack overflow detection for debug builds, with a dedicated double fault TSS to survive and diagnose overflows. It pairs this with accurate backtrace support across all panic and exception paths, refactors boot initialization, and migrates task descriptors to a page-based allocator.

### Key changes:

**Stack overflow detection (debug builds only)**

- Added a dedicated double fault TSS registered in the GDT with its own stack, allowing the CPU to execute a handler even when the faulting stack is exhausted.
- Boot stack (`STACK_PAGES` page-aligned pages) gets its first page marked non-present (`clear_present`) as a guard page after memory initialization.
- Per-task stacks similarly get a guard page at their base, automatically restored (`set_present`) on deallocation.
- The double fault handler identifies whether the faulting ESP hit a guard page (`is_guard_page`) and panics with `stack overflow` vs. `double fault` accordingly.
- Handles the x86 ESP boundary edge case: when ESP is exactly page-aligned at the guard boundary (pre-decrement hardware behavior), `fault_addr - 1` is used before alignment to correctly identify the faulting page.

**Accurate backtraces across all panic/exception paths**

- Introduced `panic_trace_override: ?StackIterator` in `logger.zig`; when set, the error logger unwinds from it instead of from the handler itself.
- `boot.zig` panic handler sets the override to unwind from the caller of `@panic`.
- Default exception handlers set the override from `frame.ebp`.
- Page fault and double fault handlers set the override from `frame.ebp` / `gdt.tss.ebp` respectively, so backtraces point at the faulting code.
- Added `cpu.invlpg()` for targeted TLB invalidation when toggling guard page presence.

**Boot initialization refactor**

- `init()` split into `init_hardware()`, `init_subsystems()`, and `init_tasks()` for clarity.
- `init_tasks()` is now `noreturn`: switches cleanly to the idle task's own stack and abandons the boot stack.
- `mapping.clear_present()` / `mapping.set_present()` introduced as helpers for guard page management.

**Task descriptor allocator**

- `TaskDescriptor` allocation migrated from a slab cache to a direct page allocator, with the descriptor and its stack colocated in the same page allocation.
- Introduced `stack_top()` helper to centralize stack pointer calculation.
- Removed the now-unnecessary `TaskDescriptor.init_cache()` call.

---

Depends-on: #234