### PR TITLE
control characters raise signals

### DIFF
--- a/src/shell/default/builtins.zig
+++ b/src/shell/default/builtins.zig
@@ -383,6 +383,9 @@ pub fn demo(shell: anytype, args: [][]u8) CmdError!void {
         if (std.mem.eql(u8, name, args[1])) {
             const new_task = @import("../../task/task_set.zig").create_task() catch
                 @panic("Failed to create new_task");
+            // A job of its own, so that the terminal can signal it without
+            // reaching the shell that started it.
+            new_task.pgid = new_task.pid;
             new_task.spawn(
                 &@import("../../task/userspace.zig").call_userspace,
                 @intFromPtr(@extern(?*fn () void, .{ .name = "userland_" ++ name }).?),

--- a/src/shell/utils.zig
+++ b/src/shell/utils.zig
@@ -216,7 +216,17 @@ pub fn pstree(shell: anytype, pid: task.TaskDescriptor.Pid, prefix: []u8, depth:
 
 const SignalId = @import("../task/signal.zig").Id;
 
+/// Wait for a job, with the terminal handed over to it for the duration.
+///
+/// A job in the foreground is the one the control characters of the terminal
+/// signal, POSIX 11.1.2. Doing it here is what a shell does with setpgid and
+/// tcsetpgrp; those do not exist yet, so the group is the job's own pid and the
+/// handover is hardcoded.
 pub fn waitpid(shell: anytype, pid: i32) void {
+    const terminal = tty.get_tty();
+    const previous = terminal.set_foreground_pgid(pid);
+    defer _ = terminal.set_foreground_pgid(previous);
+
     var status: @import("../task/wait.zig").Status = undefined;
     const ret = @import("../task/wait.zig").wait(
         pid,

--- a/src/syscall/kill.zig
+++ b/src/syscall/kill.zig
@@ -17,11 +17,20 @@ pub fn do(pid: task.TaskDescriptor.Pid, id: signal.Id) !void {
             // todo set more fields of siginfo
         });
     } else if (pid == 0) {
-        // todo: process group
+        const pgid = scheduler.get_current_task().pgid;
+        if (task_set.send_signal_to_group(pgid, .{
+            .si_signo = .{ .valid = id },
+            .si_code = .SI_USER,
+            .si_pid = scheduler.get_current_task().pid,
+        }) == 0) return Errno.ESRCH;
     } else if (pid == -1) {
         // todo: every process for which the calling process has  per-
         // mission to send signals, except for process 1
     } else { // pid < -1
-        // todo: process group with id -id
+        if (task_set.send_signal_to_group(-pid, .{
+            .si_signo = .{ .valid = id },
+            .si_code = .SI_USER,
+            .si_pid = scheduler.get_current_task().pid,
+        }) == 0) return Errno.ESRCH;
     }
 }

--- a/src/task/signal.zig
+++ b/src/task/signal.zig
@@ -62,6 +62,9 @@ pub const Code = enum(u32) {
     SI_USER,
     SEGV_ACCERR,
     SEGV_MAPERR,
+    /// Raised by the kernel rather than by a process: a terminal generating a
+    /// signal from a control character has no sender to name.
+    SI_KERNEL,
 };
 
 pub const siginfo_t = extern struct {

--- a/src/task/task_set.zig
+++ b/src/task/task_set.zig
@@ -73,3 +73,21 @@ pub fn destroy_task(pid: TaskDescriptor.Pid) !void {
     count -= 1;
     TaskDescriptor.cache.allocator().destroy(descriptor);
 }
+
+/// Send a signal to every task in a process group, and say how many got it.
+///
+/// A terminal signals a group rather than a task: the control characters of
+/// POSIX 11.1.9 reach whichever job holds the terminal, not one process of it.
+pub fn send_signal_to_group(pgid: TaskDescriptor.Pid, sig: @import("signal.zig").siginfo_t) usize {
+    scheduler.enter_critical();
+    defer scheduler.exit_critical();
+
+    var sent: usize = 0;
+    for (list) |entry| {
+        const descriptor = entry orelse continue;
+        if (descriptor.pgid != pgid) continue;
+        descriptor.send_signal(sig);
+        sent += 1;
+    }
+    return sent;
+}

--- a/src/tty/TtyStruct.zig
+++ b/src/tty/TtyStruct.zig
@@ -6,6 +6,7 @@ const std = @import("std");
 const termios = @import("termios.zig");
 const TtyDriver = @import("TtyDriver.zig");
 const InputBuffer = @import("InputBuffer.zig");
+const Pid = @import("../task/task.zig").TaskDescriptor.Pid;
 const n_tty = @import("ldisc/n_tty.zig");
 const wait_queue = @import("../task/wait_queue.zig");
 
@@ -37,6 +38,10 @@ read_queue: wait_queue.WaitQueue(.{ .predicate = input_ready }) = .{},
 
 /// Raised when the VTIME timer fires, cleared when a read starts waiting again.
 read_timed_out: bool = false,
+
+/// Process group the control characters of this terminal signal, POSIX 11.1.2.
+/// Null until something claims the terminal, and nothing is signalled then.
+foreground_pgid: ?Pid = null,
 
 // Input and reading, which the line discipline owns
 
@@ -111,6 +116,14 @@ pub fn reader(self: *Self) Reader {
 
 pub fn driver_flush(self: *Self) void {
     if (self.driver.flush) |flush| flush(self);
+}
+
+/// Hand the terminal to a process group, and give back the one it replaces so
+/// that a caller can put it back afterwards.
+pub fn set_foreground_pgid(self: *Self, pgid: ?Pid) ?Pid {
+    const previous = self.foreground_pgid;
+    self.foreground_pgid = pgid;
+    return previous;
 }
 
 /// Tell the driver whether this terminal is the one being shown.

--- a/src/tty/ldisc/n_tty.zig
+++ b/src/tty/ldisc/n_tty.zig
@@ -10,6 +10,8 @@ const termios = @import("../termios.zig");
 const scheduler = @import("../../task/scheduler.zig");
 const timer = @import("../../timer.zig");
 const TaskDescriptor = @import("../../task/task.zig").TaskDescriptor;
+const signal = @import("../../task/signal.zig");
+const task_set = @import("../../task/task_set.zig");
 
 fn cc(tty: *const TtyStruct, comptime which: termios.cc_index) u8 {
     return tty.config.c_cc[@intFromEnum(which)];
@@ -26,8 +28,43 @@ pub fn receive(tty: *TtyStruct, s: []const u8) void {
     tty.read_queue.try_unblock();
 }
 
+/// The signal a control character raises, or null when it raises none.
+/// A c_cc entry left at zero disables that character, POSIX 11.1.9.
+fn signal_char(tty: *const TtyStruct, c: u8) ?signal.Id {
+    if (!tty.config.c_lflag.ISIG) return null;
+
+    const generators = .{
+        .{ termios.cc_index.VINTR, signal.Id.SIGINT },
+        .{ termios.cc_index.VQUIT, signal.Id.SIGQUIT },
+        .{ termios.cc_index.VSUSP, signal.Id.SIGTSTP },
+    };
+    inline for (generators) |generator| {
+        const wanted = tty.config.c_cc[@intFromEnum(generator[0])];
+        if (wanted != 0 and c == wanted) return generator[1];
+    }
+    return null;
+}
+
+/// Raise a signal on the group holding the terminal, POSIX 11.1.9.
+///
+/// The half typed line goes with it unless NOFLSH says otherwise: whatever was
+/// being edited was meant for a job that is about to be interrupted.
+fn raise_signal(tty: *TtyStruct, c: u8, id: signal.Id) void {
+    echo(tty, c);
+    if (!tty.config.c_lflag.NOFLSH) tty.input_buffer.clear();
+
+    const pgid = tty.foreground_pgid orelse return;
+    _ = task_set.send_signal_to_group(pgid, .{
+        .si_signo = .{ .valid = id },
+        .si_code = .SI_KERNEL,
+        .si_pid = 0,
+    });
+}
+
 fn receive_char(tty: *TtyStruct, raw: u8) void {
     const c = input_processing(tty, raw) orelse return;
+
+    if (signal_char(tty, c)) |id| return raise_signal(tty, c, id);
 
     if (!tty.config.c_lflag.ICANON) {
         // Nothing is being edited, so a byte is readable as soon as it lands.


### PR DESCRIPTION
INTR, QUIT and SUSP were queued as ordinary input, so Ctrl-C at a running job did nothing.
They now signal the foreground process group and drop the half typed line unless NOFLSH, POSIX 11.1.9.

`kill()` only handled a single pid; `send_signal_to_group` comes with this, plus`SI_KERNEL` for a signal the kernel raises having no sender to name.

Nothing sets the foreground group yet.
`setpgid` and `tcsetpgrp` come in an upcoming PR. Until then the shell puts each job in a group of its own.

This is what exposes the delivery bugs fixed in next PR: nothing raised a kernel signal before.