### PR TITLE
fix(signals): reaching a task that is not running

### DIFF
--- a/src/interrupts.zig
+++ b/src/interrupts.zig
@@ -273,6 +273,13 @@ export fn wrapper(
     if (!interrupt_enable)
         scheduler.lock_depth -|= 1;
 
+    // A task killed by a signal is marked dead but is still on this stack, and
+    // would otherwise iret back into userspace and keep running. Giving up the
+    // processor here rather than where the signal was handled means lock_depth
+    // has already been put back: this frame is never returned to.
+    if (scheduler.is_initialized() and scheduler.get_current_task().state == .Zombie)
+        scheduler.schedule();
+
     ret_from_interrupt(frame);
 }
 

--- a/src/interrupts.zig
+++ b/src/interrupts.zig
@@ -273,15 +273,20 @@ export fn wrapper(
     if (!interrupt_enable)
         scheduler.lock_depth -|= 1;
 
-    // A task killed or stopped by a signal is marked as such but is still on
-    // this stack, and would otherwise iret back into userspace and carry on.
-    // Giving up the processor here rather than where the signal was handled
-    // means lock_depth has already been put back: this frame is never returned
-    // to, or not until a SIGCONT puts the task back on the ready queue.
-    if (scheduler.is_initialized()) switch (scheduler.get_current_task().state) {
-        .Zombie, .Stopped => scheduler.schedule(),
-        else => {},
-    };
+    // A task killed or stopped is still on this stack. Given up here and not
+    // where the signal was handled, so lock_depth is already back in balance. A
+    // continued task comes back past signal handling, hence the loop.
+    while (scheduler.is_initialized()) {
+        const state = scheduler.get_current_task().state;
+        if (state != .Zombie and state != .Stopped) break;
+
+        scheduler.schedule();
+
+        if (privilege_transition) {
+            setup_iret_frame(frame);
+            frame.* = scheduler.get_current_task().ucontext.uc_mcontext;
+        }
+    }
 
     ret_from_interrupt(frame);
 }

--- a/src/interrupts.zig
+++ b/src/interrupts.zig
@@ -273,12 +273,15 @@ export fn wrapper(
     if (!interrupt_enable)
         scheduler.lock_depth -|= 1;
 
-    // A task killed by a signal is marked dead but is still on this stack, and
-    // would otherwise iret back into userspace and keep running. Giving up the
-    // processor here rather than where the signal was handled means lock_depth
-    // has already been put back: this frame is never returned to.
-    if (scheduler.is_initialized() and scheduler.get_current_task().state == .Zombie)
-        scheduler.schedule();
+    // A task killed or stopped by a signal is marked as such but is still on
+    // this stack, and would otherwise iret back into userspace and carry on.
+    // Giving up the processor here rather than where the signal was handled
+    // means lock_depth has already been put back: this frame is never returned
+    // to, or not until a SIGCONT puts the task back on the ready queue.
+    if (scheduler.is_initialized()) switch (scheduler.get_current_task().state) {
+        .Zombie, .Stopped => scheduler.schedule(),
+        else => {},
+    };
 
     ret_from_interrupt(frame);
 }

--- a/src/shell/default/shell.zig
+++ b/src/shell/default/shell.zig
@@ -22,6 +22,7 @@ pub fn on_error(shell: *Shell) void {
 }
 
 pub fn pre_process(shell: *Shell) void {
+    utils.reap_children(shell);
     tty.flush();
     utils.print_prompt(shell);
 }

--- a/src/shell/utils.zig
+++ b/src/shell/utils.zig
@@ -236,7 +236,7 @@ pub fn waitpid(shell: anytype, pid: i32) void {
         .{
             .WNOHANG = false,
             .WCONTINUED = false,
-            .WUNTRACED = false,
+            .WUNTRACED = true,
         },
     ) catch |e| {
         shell.print_error("waitpid: wait error: {s}", .{@errorName(e)});

--- a/src/shell/utils.zig
+++ b/src/shell/utils.zig
@@ -216,6 +216,24 @@ pub fn pstree(shell: anytype, pid: task.TaskDescriptor.Pid, prefix: []u8, depth:
 
 const SignalId = @import("../task/signal.zig").Id;
 
+/// Collect the children that have died since the last prompt: nothing removes a
+/// terminated task until its parent asks for it.
+pub fn reap_children(shell: anytype) void {
+    const wait = @import("../task/wait.zig");
+    const self_pid = @import("../task/scheduler.zig").get_current_task().pid;
+
+    while (true) {
+        var status: wait.Status = undefined;
+        const pid = wait.wait(self_pid, .CHILD, &status, null, .{
+            .WNOHANG = true,
+            .WCONTINUED = false,
+            .WUNTRACED = false,
+        }) catch return;
+        if (pid == 0) return;
+        print_status(shell, pid, status);
+    }
+}
+
 /// Wait for a job, with the terminal handed over to it for the duration.
 ///
 /// A job in the foreground is the one the control characters of the terminal

--- a/src/task/signal.zig
+++ b/src/task/signal.zig
@@ -257,6 +257,16 @@ pub const SignalManager = struct {
         }
     }
 
+    /// Throw away everything queued for a signal, POSIX 2.4.3.
+    pub fn discard(self: *Self, id: Id) void {
+        self.mutex.acquire();
+        defer self.mutex.release();
+
+        const index: u32 = @intFromEnum(id);
+        while (self.queues[index].pop()) |_| {}
+        self.pending &= ~(@as(SigSet, 1) << @as(u5, @intCast(index)));
+    }
+
     pub fn get_pending_signal(self: *Self, mask: SigSet) ?siginfo_t {
         self.mutex.acquire();
         defer self.mutex.release();

--- a/src/task/signal.zig
+++ b/src/task/signal.zig
@@ -267,6 +267,16 @@ pub const SignalManager = struct {
         self.pending &= ~(@as(SigSet, 1) << @as(u5, @intCast(index)));
     }
 
+    /// The signal a blocking call would be interrupted by, without consuming it.
+    pub fn peek_pending(self: *Self, mask: SigSet) ?Id {
+        self.mutex.acquire();
+        defer self.mutex.release();
+
+        const real_mask: SigSet = mask & ~non_maskable;
+        if (self.pending & ~real_mask == 0) return null;
+        return @enumFromInt(@ctz(self.pending & ~real_mask));
+    }
+
     pub fn get_pending_signal(self: *Self, mask: SigSet) ?siginfo_t {
         self.mutex.acquire();
         defer self.mutex.release();

--- a/src/task/sleep.zig
+++ b/src/task/sleep.zig
@@ -4,6 +4,9 @@ const ready_queue = @import("ready_queue.zig");
 const timer = @import("../timer.zig");
 
 fn unblock_task(t: *task.TaskDescriptor, _: *usize) void {
+    // An event that outlived what scheduled it must not requeue a task that has
+    // since been stopped or killed.
+    if (t.state != .Blocked) return;
     ready_queue.push(t);
 }
 
@@ -13,11 +16,15 @@ pub fn usleep(micro: u64) !void {
 
     const t = scheduler.get_current_task();
 
-    _ = timer.schedule_event(timer.Event{
+    const wake_up = timer.schedule_event(timer.Event{
         .timestamp = timer.get_utime_since_boot() + micro,
         .callback = unblock_task,
         .task = t,
     }) catch return error.ENOMEM;
+    // A sleep cut short by a signal has no use for its wake up any more, and
+    // leaving it behind is what lets a stopped task be made runnable again by
+    // the sleep it was in when it was stopped.
+    defer timer.remove_by_id(wake_up);
 
     ready_queue.remove(t);
     t.state = .Blocked;

--- a/src/task/sleep.zig
+++ b/src/task/sleep.zig
@@ -10,26 +10,35 @@ fn unblock_task(t: *task.TaskDescriptor, _: *usize) void {
     ready_queue.push(t);
 }
 
+/// Sleep until an instant, not for a duration: a task stopped mid-sleep pauses
+/// on this stack and waits out the rest, so time spent stopped counts.
 pub fn usleep(micro: u64) !void {
     scheduler.enter_critical();
     defer scheduler.exit_critical();
 
     const t = scheduler.get_current_task();
+    const deadline = timer.get_utime_since_boot() + micro;
 
-    const wake_up = timer.schedule_event(timer.Event{
-        .timestamp = timer.get_utime_since_boot() + micro,
-        .callback = unblock_task,
-        .task = t,
-    }) catch return error.ENOMEM;
-    // A sleep cut short by a signal has no use for its wake up any more, and
-    // leaving it behind is what lets a stopped task be made runnable again by
-    // the sleep it was in when it was stopped.
-    defer timer.remove_by_id(wake_up);
+    while (timer.get_utime_since_boot() < deadline) {
+        const wake_up = timer.schedule_event(timer.Event{
+            .timestamp = deadline,
+            .callback = unblock_task,
+            .task = t,
+        }) catch return error.ENOMEM;
 
-    ready_queue.remove(t);
-    t.state = .Blocked;
+        ready_queue.remove(t);
+        t.state = .Blocked;
+        scheduler.schedule();
 
-    scheduler.schedule();
+        // Either it fired, or a signal got there first and it must not later.
+        timer.remove_by_id(wake_up);
+
+        switch (t.pending_disposition()) {
+            .stop => t.stop_in_place(),
+            .interrupt => return error.EINTR,
+            .none => {},
+        }
+    }
 }
 
 pub fn sleep(millis: u64) !void {

--- a/src/task/task.zig
+++ b/src/task/task.zig
@@ -204,6 +204,7 @@ pub const TaskDescriptor = struct {
     fn handle_default_action(self: *Self, sig: signal.siginfo_t) void {
         switch (self.signalManager.get_defaultAction(sig.si_signo.unwrap())) {
             .Ignore => {},
+            // Marks the task; not returning to userspace is decided in wrapper.
             .Terminate => {
                 if (self.state == .Ready)
                     ready_queue.remove(self);

--- a/src/task/task.zig
+++ b/src/task/task.zig
@@ -292,11 +292,27 @@ pub const TaskDescriptor = struct {
         }
     }
 
+    /// Queue a signal, and decide here what it does to a task that is not
+    /// running: signals are only acted on when a task returns to userspace.
     pub fn send_signal(self: *Self, sig: signal.siginfo_t) void {
+        const id = sig.si_signo.safeUnwrap() orelse return;
+
+        // A stop and a continue cancel each other out, POSIX 2.4.3.
+        switch (self.signalManager.get_defaultAction(id)) {
+            .Continue => for ([_]signal.Id{ .SIGSTOP, .SIGTSTP, .SIGTTIN, .SIGTTOU }) |stop|
+                self.signalManager.discard(stop),
+            .Stop => self.signalManager.discard(.SIGCONT),
+            else => {},
+        }
+
         self.signalManager.queue_signal(sig);
-        if (sig.si_signo.safeUnwrap() == .SIGCONT and self.state == .Stopped) {
-            self.state = .Ready;
-            ready_queue.push(self);
+
+        if (self.state == .Stopped) {
+            // SIGKILL too: it can be neither blocked nor ignored.
+            if (id == .SIGCONT or id == .SIGKILL) {
+                self.state = .Ready;
+                ready_queue.push(self);
+            }
         } else if (self.state == .Blocked) {
             @import("wait_queue.zig").interrupt(self);
         }

--- a/src/task/task.zig
+++ b/src/task/task.zig
@@ -142,6 +142,36 @@ pub const TaskDescriptor = struct {
         }
     }
 
+    /// What a blocking call should do about whatever signal is waiting.
+    pub const Disposition = enum { none, stop, interrupt };
+
+    pub fn pending_disposition(self: *Self) Disposition {
+        const id = self.signalManager.peek_pending(self.ucontext.uc_sigmask) orelse return .none;
+        // A handler runs, which is an interruption whatever the signal meant.
+        if (self.signalManager.get_action(id).sa_handler != signal.SIG_DFL) return .interrupt;
+
+        return switch (self.signalManager.get_defaultAction(id)) {
+            .Stop => .stop,
+            .Terminate => .interrupt,
+            .Ignore, .Continue => .none,
+        };
+    }
+
+    /// Stop on the caller's own stack rather than on the way out to userspace,
+    /// so a blocking call resumes instead of returning short.
+    pub fn stop_in_place(self: *Self) void {
+        const info = self.signalManager.get_pending_signal(self.ucontext.uc_sigmask) orelse return;
+
+        if (self.state == .Ready) ready_queue.remove(self);
+        self.state = .Stopped;
+        self.update_status(.{
+            .transition = .Stopped,
+            .signaled = true,
+            .siginfo = info,
+        });
+        scheduler.schedule();
+    }
+
     pub fn update_status(self: *Self, new_status_info: ?status_informations.Status) void {
         self.status_info = new_status_info;
         if (new_status_info) |s| {

--- a/src/tty/ldisc/n_tty.zig
+++ b/src/tty/ldisc/n_tty.zig
@@ -181,10 +181,24 @@ fn arm_timer(tty: *TtyStruct, deciseconds: u8) ?u64 {
     }) catch null;
 }
 
-/// Sleep until the discipline publishes something or VTIME runs out.
+/// Sleep until the discipline publishes something or VTIME runs out. A stop
+/// pauses the read on this stack rather than ending it.
 fn wait(tty: *TtyStruct) TtyStruct.ReadError!void {
-    tty.read_queue.block(scheduler.get_current_task(), @ptrCast(tty)) catch
-        return error.EINTR;
+    const task = scheduler.get_current_task();
+
+    while (true) {
+        tty.read_queue.block(task, @ptrCast(tty)) catch {};
+
+        // Input beats a signal that is only waiting.
+        if (tty.read_timed_out or has_input(tty)) return;
+
+        switch (task.pending_disposition()) {
+            .stop => task.stop_in_place(),
+            .interrupt => return error.EINTR,
+            // Woken by nothing in particular; wait again.
+            .none => {},
+        }
+    }
 }
 
 /// Hand bytes to a reader. Canonical mode ignores VMIN and VTIME: a line is the


### PR DESCRIPTION
Signals are only delivered at one point, `setup_iret_frame`, on the way back to userspace.
A task that no longer runs never gets there, so anything that must reach it has to be decided when the signal is raised (what `prepare_signal` does on Linux).

- `interrupts.zig`: `terminate()` marked a task dead but left it on its stack, so it returned to userspace and kept running; a routine exiting on its own then overwrote the killed status
- Same for a stopped task, plus `WUNTRACED` in the shell, which waited on a task that would not run again. Ctrl-Z looked frozen; only the prompt was missing.
- `task.zig`: SIGKILL wakes a stopped task; a stop and a continue discard each other, POSIX 2.4.3.
- `shell/utils.zig`: the prompt reaps dead children. A job stopped then killed kept its pid for good.
- `sleep.zig`: an interrupted sleep left its timer event behind, and the event pushed the task back on the ready queue whatever its state.

**The last two commits are the logical consequences**: a stop is not an interruption, a blocking call has to resume. `sleep` now sleeps until an instant rather than for a duration, so time spent stopped counts; the TTY read no longer reports EINTR when a stop wakes it. Both stop on their own stack and come back to it.