### PR TITLE
terminals as character devices

### DIFF
--- a/src/boot.zig
+++ b/src/boot.zig
@@ -103,6 +103,7 @@ export fn init(eax: u32, ebx: u32) callconv(.c) void {
     @import("device/block/registry.zig").init();
     @import("device/char/registry.zig").init();
     @import("drivers/char/mem.zig").init();
+    @import("drivers/tty/tty_cdev.zig").init();
 
     @import("drivers/pci/pci.zig").init() catch @panic("Failed to initialize PCI subsystem");
     @import("drivers/ide/ide.zig").init() catch @panic("Failed to initialize IDE subsystem");

--- a/src/boot.zig
+++ b/src/boot.zig
@@ -5,6 +5,7 @@ const multiboot = @import("multiboot.zig");
 const builtin = std.builtin;
 const paging = @import("memory/paging.zig");
 const vfs = @import("fs/vfs.zig");
+const Tnode = @import("fs/tnode.zig");
 const CommandLine = @import("command_line.zig");
 const log = std.log;
 
@@ -124,6 +125,10 @@ export fn init(eax: u32, ebx: u32) callconv(.c) void {
     vfs.add_filesystem(@import("drivers/devfs/driver.zig").fs) catch @panic("Failed to initialize devfs.");
     @import("drivers/ext2/driver.zig").static_init() catch @panic("Failed to initialize ext2.");
     vfs.add_filesystem(@import("drivers/ext2/driver.zig").fs) catch @panic("Failed to initialize ext2.");
+
+    // /dev has to exist before anything can open a terminal by name.
+    const dev = Tnode.plant(vfs.get_hard_root(), "dev") catch @panic("Cannot create /dev");
+    vfs.mount(dev, .virtual, .{ .fs = "devfs" }) catch @panic("Cannot mount devfs");
 
     const root = CommandLine.get().root;
     if (root != .virtual) {

--- a/src/drivers/tty/tty_cdev.zig
+++ b/src/drivers/tty/tty_cdev.zig
@@ -1,0 +1,61 @@
+// The terminals as character special files, POSIX 11.1.1. Major 4, one minor
+// per console, named ttyN by devfs from the registry.
+
+const std = @import("std");
+
+const File = @import("../../fs/file.zig");
+const char = @import("../../device/char/char.zig");
+const CharDevice = @import("../../device/char/cdev.zig");
+const registry = @import("../../device/char/registry.zig");
+const types = @import("../../device/types.zig");
+
+const tty = @import("../../tty/tty.zig");
+const TtyStruct = @import("../../tty/TtyStruct.zig");
+
+const log = std.log.scoped(.tty_cdev);
+
+const MAJOR: types.major_t = 4;
+
+var cdevs: [tty.max_tty + 1]CharDevice = undefined;
+
+/// fs/character.zig leaves the device in `data`; what follows needs the
+/// terminal it stands for.
+fn open(dev: *CharDevice, file: *File) char.CharError!void {
+    file.vtable = &file_vtable;
+    file.data = &tty.tty_array[dev.devt.minor];
+}
+
+fn terminal(file: *File) *TtyStruct {
+    return @ptrCast(@alignCast(file.data.?));
+}
+
+fn read(file: *File, buffer: []u8) File.Error.read!usize {
+    return terminal(file).read(buffer);
+}
+
+fn write(file: *File, data: []const u8) File.Error.write!usize {
+    return terminal(file).write(data);
+}
+
+pub const ops = char.Operations{ .open = &open };
+
+pub const file_vtable = File.VTable{
+    .read = &read,
+    .write = &write,
+    .close = &File.VTable.Generic.close,
+};
+
+pub fn init() void {
+    registry.register_char_dev(MAJOR, "tty") catch |err| {
+        log.err("cannot reserve major {d}: {s}", .{ MAJOR, @errorName(err) });
+        return;
+    };
+
+    for (&cdevs, 0..) |*dev, i| {
+        var buffer: [CharDevice.CDEV_NAME_LEN]u8 = undefined;
+        const name = std.fmt.bufPrint(&buffer, "tty{d}", .{i}) catch continue;
+        dev.* = CharDevice.init(name, MAJOR, @intCast(i), &ops);
+        dev.register() catch |err|
+            log.err("cannot register {s}: {s}", .{ name, @errorName(err) });
+    }
+}

--- a/src/fs/file.zig
+++ b/src/fs/file.zig
@@ -29,6 +29,8 @@ pub const Error = struct {
         EPERM,
         ENXIO,
         EINVAL,
+        /// A read cut short by a signal. Zero already means end of input.
+        EINTR,
     };
     pub const write = error{
         EBUSY,

--- a/src/fs/tnode.zig
+++ b/src/fs/tnode.zig
@@ -80,6 +80,32 @@ pub fn release(self: *Self) void {
     }
 }
 
+/// Put a name under `parent` without asking the filesystem for it.
+///
+/// Scaffolding: the root filesystem cannot hold entries, so a mount point has
+/// to be planted directly. Remove once rootfs can create directories.
+pub fn plant(parent: *Self, name: []const u8) !*Self {
+    const tnode = try create();
+    errdefer destroy(tnode);
+
+    const owned_name = try memory.smallAlloc.allocator().dupe(u8, name);
+    errdefer memory.smallAlloc.allocator().free(owned_name);
+
+    tnode.* = .{
+        .inode = parent.inode.get_ref(),
+        .name = owned_name,
+        .parent = parent.get_ref(),
+        .refs = 1,
+    };
+    parent.inode.type_specific.Directory.children.append(&tnode.sibling_node);
+    try tnodeCache.put(
+        memory.bigAlloc.allocator(),
+        .{ .inode = parent.inode, .name = owned_name },
+        tnode,
+    );
+    return tnode;
+}
+
 pub fn mount(self: *Self, inode: *Inode) void {
     logger.debug("mount tnode: {*}", .{self});
     if (self.mountpoint) |_| {

--- a/src/shell/default/builtins.zig
+++ b/src/shell/default/builtins.zig
@@ -610,9 +610,12 @@ pub fn write(shell: anytype, args: [][]u8) CmdError!void {
         return CmdError.OtherError;
     };
 
-    if (file_tnode.inode.mode.type != .Regular and file_tnode.inode.mode.type != .Fifo) {
-        utils.print_error(shell, "Invalid path: {s} is not a regular file", .{args[1]});
-        return CmdError.OtherError;
+    switch (file_tnode.inode.mode.type) {
+        .Regular, .Fifo, .Character => {},
+        else => {
+            utils.print_error(shell, "Invalid path: {s} cannot be written to", .{args[1]});
+            return CmdError.OtherError;
+        },
     }
 
     const file = try translate_errno(shell, file_tnode.inode.open());


### PR DESCRIPTION
`drivers/tty/tty_cdev.zig`, new. Major 4, one minor per console. Follows thepattern of `drivers/char/mem/null.zig`; `fs/character.zig` does the rest.

What spills over:

- `File.Error.read` gains `EINTR`. A read cut short by a signal returned zero, which already means end of input, so Ctrl-C at the prompt read as Ctrl-D. Same fix as your `ri/fs/devfs` POC.
- devfs was registered but never mounted, and `ls /dev` said "dev does not exist". The virtual root cannot hold a mount point: `root_lookup` returns null, `root_open` and `link` return EPERM.
  Hence **scaffolding**: `Tnode.plant` puts a tnode under a parent without going through the filesystem. Drop it once
  rootfs can create directories.
- The `write` builtin refused anything but `.Regular` and `.Fifo`, hence all of `/dev`.