### PR TITLE
termios ABI, tcgetattr and tcsetattr

### DIFF
--- a/src/drivers/tty/tty_cdev.zig
+++ b/src/drivers/tty/tty_cdev.zig
@@ -11,6 +11,8 @@ const types = @import("../../device/types.zig");
 
 const tty = @import("../../tty/tty.zig");
 const TtyStruct = @import("../../tty/TtyStruct.zig");
+const termios = @import("../../tty/termios.zig");
+const control = @import("../../tty/ioctl.zig");
 
 const log = std.log.scoped(.tty_cdev);
 
@@ -37,12 +39,33 @@ fn write(file: *File, data: []const u8) File.Error.write!usize {
     return terminal(file).write(data);
 }
 
+/// The control requests POSIX reaches through tcgetattr and tcsetattr. With no
+/// output queue, DRAIN and FLUSH apply at once like NOW.
+fn ioctl(file: *File, request: u32, arg: usize) File.Error.ioctl!usize {
+    const terminal_ = terminal(file);
+
+    switch (@as(control.Request, @enumFromInt(request))) {
+        .TCGETS => {
+            const out: *termios.abi.Termios = @ptrFromInt(arg);
+            out.* = termios.to_abi(terminal_.config);
+        },
+        .TCSETS, .TCSETSW, .TCSETSF => |request_| {
+            const new: *const termios.abi.Termios = @ptrFromInt(arg);
+            if (request_ == .TCSETSF) terminal_.input_buffer.clear();
+            terminal_.set_termios(termios.from_abi(new.*));
+        },
+        else => return error.EINVAL,
+    }
+    return 0;
+}
+
 pub const ops = char.Operations{ .open = &open };
 
 pub const file_vtable = File.VTable{
     .read = &read,
     .write = &write,
     .close = &File.VTable.Generic.close,
+    .ioctl = &ioctl,
 };
 
 pub fn init() void {

--- a/src/fs/file.zig
+++ b/src/fs/file.zig
@@ -48,6 +48,12 @@ pub const Error = struct {
         ENOMEM,
         EPERM,
     };
+    pub const ioctl = error{
+        ENOTTY,
+        EINVAL,
+        EIO,
+        EPERM,
+    };
     pub const seek = error{
         EOVERFLOW,
         EINVAL,
@@ -97,6 +103,10 @@ pub const VTable = struct {
     readdir: ?*const fn (*Self, *DirEnt) Error.readdir!bool = null,
     seek: ?*const fn (self: *Self, offset: Off, whence: Seek) Error.seek!Off = null,
     write: ?*const fn (*Self, []const u8) Error.write!usize = null,
+
+    /// Device control. The terminal calls POSIX exposes as tcgetattr and the
+    /// like all end up here.
+    ioctl: ?*const fn (*Self, request: u32, arg: usize) Error.ioctl!usize = null,
 
     pub const Generic = struct {
         pub fn close(self: *Self) Error.close!void {
@@ -214,6 +224,13 @@ pub fn write(self: *Self, buffer: []const u8) Error.write!usize {
 
 pub fn readdir(self: *Self, dst: *DirEnt) Error.readdir!bool {
     return self.call_or_panic(.readdir, .{dst});
+}
+
+/// Not call_or_panic: answering no control request is ordinary, and POSIX
+/// names it ENOTTY.
+pub fn ioctl(self: *Self, request: u32, arg: usize) Error.ioctl!usize {
+    const f = self.vtable.ioctl orelse return error.ENOTTY;
+    return f(self, request, arg);
 }
 
 pub fn seek(self: *Self, offset: Off, whence: Seek) Error.seek!Off {

--- a/src/shell/default/builtins.zig
+++ b/src/shell/default/builtins.zig
@@ -898,3 +898,56 @@ pub fn ttyread(shell: anytype, args: [][]u8) CmdError!void {
     for (buffer[0..read]) |c| shell.print(" {x:0>2}", .{c});
     shell.print("\n", .{});
 }
+
+/// Read or change the termios of a terminal, by the path userspace takes.
+/// Usage: stty <path> [raw|sane]
+pub fn stty(shell: anytype, args: [][]u8) CmdError!void {
+    if (args.len < 2 or args.len > 3) return CmdError.InvalidNumberOfArguments;
+
+    const termios = @import("../../tty/termios.zig");
+    const control = @import("../../tty/ioctl.zig");
+
+    const tnode = vfs.resolve(args[1]) catch {
+        utils.print_error(shell, "Invalid path: {s} does not exist", .{args[1]});
+        return CmdError.OtherError;
+    };
+    defer tnode.release();
+
+    const file = try translate_errno(shell, tnode.inode.open());
+    defer file.close() catch {};
+
+    var attr: termios.abi.Termios = undefined;
+    _ = try translate_errno(
+        shell,
+        file.ioctl(@intFromEnum(control.Request.TCGETS), @intFromPtr(&attr)),
+    );
+
+    if (args.len == 3) {
+        if (std.mem.eql(u8, args[2], "raw")) {
+            attr.c_lflag.ICANON = false;
+            attr.c_lflag.ECHO = false;
+            attr.c_cc[@intFromEnum(termios.cc_index.VMIN)] = 1;
+            attr.c_cc[@intFromEnum(termios.cc_index.VTIME)] = 0;
+        } else if (std.mem.eql(u8, args[2], "sane")) {
+            attr = termios.to_abi(.{});
+        } else return CmdError.InvalidParameter;
+
+        _ = try translate_errno(
+            shell,
+            file.ioctl(@intFromEnum(control.Request.TCSETSF), @intFromPtr(&attr)),
+        );
+    }
+
+    shell.print("iflag {b:0>12} oflag {b:0>8} lflag {b:0>10}\n", .{
+        @as(u12, @truncate(@as(u32, @bitCast(attr.c_iflag)))),
+        @as(u8, @truncate(@as(u32, @bitCast(attr.c_oflag)))),
+        @as(u10, @truncate(@as(u32, @bitCast(attr.c_lflag)))),
+    });
+    shell.print("icanon {} echo {} isig {} vmin {d} vtime {d}\n", .{
+        attr.c_lflag.ICANON,
+        attr.c_lflag.ECHO,
+        attr.c_lflag.ISIG,
+        attr.c_cc[@intFromEnum(termios.cc_index.VMIN)],
+        attr.c_cc[@intFromEnum(termios.cc_index.VTIME)],
+    });
+}

--- a/src/syscall/tcgetattr.zig
+++ b/src/syscall/tcgetattr.zig
@@ -1,0 +1,11 @@
+const scheduler = @import("../task/scheduler.zig");
+const FileSet = @import("../task/file_set.zig");
+const termios = @import("../tty/termios.zig");
+const control = @import("../tty/ioctl.zig");
+
+pub const Id = 36;
+
+pub fn do(fd: FileSet.Fd, out: *termios.abi.Termios) !void {
+    const file = try scheduler.get_current_task().files.get(fd);
+    _ = try file.ioctl(@intFromEnum(control.Request.TCGETS), @intFromPtr(out));
+}

--- a/src/syscall/tcsetattr.zig
+++ b/src/syscall/tcsetattr.zig
@@ -1,0 +1,20 @@
+const scheduler = @import("../task/scheduler.zig");
+const FileSet = @import("../task/file_set.zig");
+const termios = @import("../tty/termios.zig");
+const control = @import("../tty/ioctl.zig");
+
+pub const Id = 37;
+
+/// `actions` says when the change takes effect, POSIX 11.2. A plain integer,
+/// since a value outside the set has to be answered with EINVAL.
+pub fn do(fd: FileSet.Fd, actions: u32, new: *const termios.abi.Termios) !void {
+    const request: control.Request = switch (actions) {
+        @intFromEnum(control.SetAction.NOW) => .TCSETS,
+        @intFromEnum(control.SetAction.DRAIN) => .TCSETSW,
+        @intFromEnum(control.SetAction.FLUSH) => .TCSETSF,
+        else => return error.EINVAL,
+    };
+
+    const file = try scheduler.get_current_task().files.get(fd);
+    _ = try file.ioctl(@intFromEnum(request), @intFromPtr(new));
+}

--- a/src/tty/ioctl.zig
+++ b/src/tty/ioctl.zig
@@ -1,0 +1,30 @@
+// The control requests a terminal answers. POSIX exposes these as tcgetattr,
+// tcsetattr and the rest, each reaching here through its own syscall. The
+// numbers are ours, except the three mlibc hardcodes.
+
+pub const Request = enum(u32) {
+    /// Read the current termios.
+    TCGETS = 1,
+    /// Apply new termios at once.
+    TCSETS = 2,
+    /// Apply once the output has drained.
+    TCSETSW = 3,
+    /// Apply once the output has drained, discarding pending input.
+    TCSETSF = 4,
+
+    // Wired into options/posix/include/termios.h in mlibc, so not ours to pick.
+    TIOCGPGRP = 0x540F,
+    TIOCSPGRP = 0x5410,
+    TIOCGSID = 0x5429,
+
+    _,
+};
+
+/// When tcsetattr should take effect, POSIX 11.2.
+pub const SetAction = enum(u32) {
+    NOW = 0,
+    /// Once the output written so far has been sent.
+    DRAIN = 1,
+    /// As DRAIN, and throw away the input not yet read.
+    FLUSH = 2,
+};

--- a/src/tty/termios.zig
+++ b/src/tty/termios.zig
@@ -136,3 +136,133 @@ pub const termios = struct {
         0,
     },
 };
+
+/// The shape a terminal takes when it crosses into userspace.
+///
+/// The kernel keeps its own `termios` above and converts at the syscall
+/// boundary, so the two can change independently. Flags are numbered by what is
+/// honoured, and the speed is bits per second in its own field rather than an
+/// index in c_cflag. B134 loses its half.
+pub const abi = struct {
+    /// Spelled out rather than aliased: abi-bits/termios.h declares these.
+    pub const flag_word = u32;
+    pub const speed = u32;
+    pub const control_char = u8;
+
+    pub const iflag = packed struct(flag_word) {
+        // Honoured.
+        ISTRIP: bool = false,
+        ICRNL: bool = false,
+        INLCR: bool = false,
+        IGNCR: bool = false,
+        // Declared only.
+        BRKINT: bool = false,
+        IGNBRK: bool = false,
+        IGNPAR: bool = false,
+        INPCK: bool = false,
+        PARMRK: bool = false,
+        IXON: bool = false,
+        IXOFF: bool = false,
+        IXANY: bool = false,
+        _: u20 = 0,
+    };
+
+    pub const oflag = packed struct(flag_word) {
+        // Honoured.
+        OPOST: bool = false,
+        ONLCR: bool = false,
+        OCRNL: bool = false,
+        ONLRET: bool = false,
+        // Declared only.
+        OLCUC: bool = false,
+        ONOCR: bool = false,
+        OFILL: bool = false,
+        OFDEL: bool = false,
+        _: u24 = 0,
+    };
+
+    /// Nothing here is honoured yet: these describe a line, not a screen.
+    pub const cflag = packed struct(flag_word) {
+        CSIZE: bool = false,
+        CSTOPB: bool = false,
+        CREAD: bool = false,
+        PARENB: bool = false,
+        PARODD: bool = false,
+        HUPCL: bool = false,
+        CLOCAL: bool = false,
+        _: u25 = 0,
+    };
+
+    pub const lflag = packed struct(flag_word) {
+        // Honoured.
+        ICANON: bool = false,
+        ECHO: bool = false,
+        ECHOE: bool = false,
+        ECHOK: bool = false,
+        ECHONL: bool = false,
+        ECHOCTL: bool = false,
+        ISIG: bool = false,
+        NOFLSH: bool = false,
+        // Declared only.
+        IEXTEN: bool = false,
+        TOSTOP: bool = false,
+        _: u22 = 0,
+    };
+
+    /// Named rather than left to the compiler, the same layout being written
+    /// by hand in abi-bits/termios.h.
+    pub const Termios = extern struct {
+        c_iflag: iflag,
+        c_oflag: oflag,
+        c_cflag: cflag,
+        c_lflag: lflag,
+        c_cc: [NCCS]control_char,
+        c_ibaud: speed,
+        c_obaud: speed,
+    };
+};
+
+/// Build an ABI flag word from the kernel's own. Mapped by name and not by
+/// bit: renaming a flag stops the build instead of quietly dropping it.
+fn to_abi_flags(comptime Abi: type, kernel: anytype) Abi {
+    var out: Abi = .{};
+    inline for (@typeInfo(Abi).@"struct".fields) |field| {
+        if (comptime field.name[0] == '_') continue;
+        @field(out, field.name) = @field(kernel, field.name);
+    }
+    return out;
+}
+
+/// The reverse. Flags the kernel has and the ABI does not keep their default.
+fn from_abi_flags(comptime Kernel: type, word: anytype) Kernel {
+    var out: Kernel = .{};
+    inline for (@typeInfo(@TypeOf(word)).@"struct".fields) |field| {
+        if (comptime field.name[0] == '_') continue;
+        @field(out, field.name) = @field(word, field.name);
+    }
+    return out;
+}
+
+/// What userspace is handed for this terminal.
+pub fn to_abi(self: termios) abi.Termios {
+    return .{
+        .c_iflag = to_abi_flags(abi.iflag, self.c_iflag),
+        .c_oflag = to_abi_flags(abi.oflag, self.c_oflag),
+        .c_cflag = to_abi_flags(abi.cflag, self.c_cflag),
+        .c_lflag = to_abi_flags(abi.lflag, self.c_lflag),
+        .c_cc = self.c_cc,
+        .c_ibaud = 0,
+        .c_obaud = 0,
+    };
+}
+
+/// What userspace asked for, in the terms the line discipline works in.
+pub fn from_abi(new: abi.Termios) termios {
+    return .{
+        .c_iflag = from_abi_flags(iflags, new.c_iflag),
+        .c_oflag = from_abi_flags(oflags, new.c_oflag),
+        .c_cflag = from_abi_flags(cflags, new.c_cflag),
+        .c_lflag = from_abi_flags(lflags, new.c_lflag),
+        .c_cc = new.c_cc,
+    };
+}


### PR DESCRIPTION
The kernel keeps its own `termios`, laid out for the line discipline, and converts at the syscall boundary.
Two deliberate divergences from Linux, both left free by POSIX:
- flags numbered by what is honoured, so what the discipline acts on holds the low bits of its word
- the speed as bits per second in `c_ibaud`/`c_obaud`, not an index in `c_cflag`

The conversion is driven by the ABI's field list, so renaming a flag breaks the build instead of silently dropping it.
`fs/file.zig` gains an `ioctl` vtable entry, returning `ENOTTY` when absent rather than panicking like the other entries.

No output queue yet, so TCSADRAIN and TCSAFLUSH apply at once like TCSANOW; TCSAFLUSH's input discard is done