### PR TITLE
sessions and the controlling terminal

### DIFF
--- a/src/drivers/tty/tty_cdev.zig
+++ b/src/drivers/tty/tty_cdev.zig
@@ -13,6 +13,8 @@ const tty = @import("../../tty/tty.zig");
 const TtyStruct = @import("../../tty/TtyStruct.zig");
 const termios = @import("../../tty/termios.zig");
 const control = @import("../../tty/ioctl.zig");
+const scheduler = @import("../../task/scheduler.zig");
+const TaskDescriptor = @import("../../task/task.zig").TaskDescriptor;
 
 const log = std.log.scoped(.tty_cdev);
 
@@ -74,6 +76,24 @@ fn ioctl(file: *File, request: u32, arg: usize) File.Error.ioctl!usize {
             const new: *const termios.abi.Termios = @ptrFromInt(arg);
             if (request_ == .TCSETSF) terminal_.input_buffer.clear();
             terminal_.set_termios(termios.from_abi(new.*));
+        },
+        .TIOCGSID => {
+            // POSIX tcgetsid: a terminal no session answers for is not the
+            // caller's either.
+            const owner = terminal_.session orelse return error.ENOTTY;
+            const out: *TaskDescriptor.Pid = @ptrFromInt(arg);
+            out.* = owner.sid;
+        },
+        .TIOCSCTTY => {
+            const task = scheduler.get_current_task();
+            if (task.session.sid != task.pid) return error.EPERM;
+            // Stealing a terminal from another session is not offered.
+            task.session.claim(terminal_, task.pgid) catch return error.EPERM;
+        },
+        .TIOCNOTTY => {
+            const session = scheduler.get_current_task().session;
+            if (session.ctty != terminal_) return error.ENOTTY;
+            session.hangup();
         },
         else => return error.EINVAL,
     }

--- a/src/drivers/tty/tty_cdev.zig
+++ b/src/drivers/tty/tty_cdev.zig
@@ -31,6 +31,13 @@ fn terminal(file: *File) *TtyStruct {
     return @ptrCast(@alignCast(file.data.?));
 }
 
+/// The terminal an open file stands for, or null. The vtable tells them apart:
+/// only a file opened here carries a TtyStruct in `data`.
+pub fn terminal_of(file: *File) ?*TtyStruct {
+    if (file.vtable != &file_vtable) return null;
+    return terminal(file);
+}
+
 fn read(file: *File, buffer: []u8) File.Error.read!usize {
     return terminal(file).read(buffer);
 }

--- a/src/drivers/tty/tty_cdev.zig
+++ b/src/drivers/tty/tty_cdev.zig
@@ -18,7 +18,11 @@ const log = std.log.scoped(.tty_cdev);
 
 const MAJOR: types.major_t = 4;
 
+/// /dev/tty, resolved at every open to the caller's controlling terminal.
+const CTTY_MAJOR: types.major_t = 5;
+
 var cdevs: [tty.max_tty + 1]CharDevice = undefined;
+var ctty_cdev: CharDevice = undefined;
 
 /// fs/character.zig leaves the device in `data`; what follows needs the
 /// terminal it stands for.
@@ -26,6 +30,16 @@ fn open(dev: *CharDevice, file: *File) char.CharError!void {
     file.vtable = &file_vtable;
     file.data = &tty.tty_array[dev.devt.minor];
 }
+
+/// Open the controlling terminal of the calling session, POSIX 11.1.1. A
+/// session without one gets ENXIO.
+fn open_ctty(_: *CharDevice, file: *File) char.CharError!void {
+    const session = @import("../../task/scheduler.zig").get_current_task().session;
+    file.data = session.ctty orelse return error.DeviceNotFound;
+    file.vtable = &file_vtable;
+}
+
+const ctty_ops = char.Operations{ .open = &open_ctty };
 
 fn terminal(file: *File) *TtyStruct {
     return @ptrCast(@alignCast(file.data.?));
@@ -80,6 +94,14 @@ pub fn init() void {
         log.err("cannot reserve major {d}: {s}", .{ MAJOR, @errorName(err) });
         return;
     };
+
+    registry.register_char_dev(CTTY_MAJOR, "tty") catch |err| {
+        log.err("cannot reserve major {d}: {s}", .{ CTTY_MAJOR, @errorName(err) });
+        return;
+    };
+    ctty_cdev = CharDevice.init("tty", CTTY_MAJOR, 0, &ctty_ops);
+    ctty_cdev.register() catch |err|
+        log.err("cannot register tty: {s}", .{@errorName(err)});
 
     for (&cdevs, 0..) |*dev, i| {
         var buffer: [CharDevice.CDEV_NAME_LEN]u8 = undefined;

--- a/src/fs/character.zig
+++ b/src/fs/character.zig
@@ -13,7 +13,13 @@ pub fn open(base: *Inode, file: *File) Inode.Error.open!void {
         .refs = 1,
         .data = device,
     };
-    device.open(file) catch return error.EIO;
+    // /dev/tty without a controlling terminal has to reach the caller as ENXIO.
+    device.open(file) catch |err| return switch (err) {
+        error.DeviceNotFound => error.ENXIO,
+        error.OutOfMemory => error.ENOMEM,
+        error.PermissionDenied => error.EPERM,
+        else => error.EIO,
+    };
 }
 
 fn read(file: *File, buffer: []u8) File.Error.read!usize {

--- a/src/shell/default/builtins.zig
+++ b/src/shell/default/builtins.zig
@@ -951,3 +951,31 @@ pub fn stty(shell: anytype, args: [][]u8) CmdError!void {
         attr.c_cc[@intFromEnum(termios.cc_index.VTIME)],
     });
 }
+
+/// Show the session and process group of a task, and the terminal the session
+/// controls. Zero, or no argument, means the shell itself.
+/// Usage: session [pid]
+pub fn session(shell: anytype, args: [][]u8) CmdError!void {
+    if (args.len > 2) return CmdError.InvalidNumberOfArguments;
+
+    const task_set = @import("../../task/task_set.zig");
+    const pid = if (args.len == 2)
+        std.fmt.parseInt(i32, args[1], 0) catch return CmdError.InvalidParameter
+    else
+        0;
+
+    const task = if (pid == 0)
+        scheduler.get_current_task()
+    else
+        task_set.get_task_descriptor(pid) orelse {
+            utils.print_error(shell, "No such task: {d}", .{pid});
+            return CmdError.OtherError;
+        };
+
+    shell.print("pid {d} pgid {d} sid {d}", .{ task.pid, task.pgid, task.session.sid });
+    if (task.session.ctty) |terminal| {
+        shell.print(" ctty tty{d} fg {?d}\n", .{ terminal.index, terminal.foreground_pgid });
+    } else {
+        shell.print(" no controlling terminal\n", .{});
+    }
+}

--- a/src/shell/default/builtins.zig
+++ b/src/shell/default/builtins.zig
@@ -1013,3 +1013,36 @@ pub fn ctty(shell: anytype, args: [][]u8) CmdError!void {
     };
     shell.print("fd {d}\n", .{fd});
 }
+
+/// Send a control request to an open path, as userspace reaches tcgetsid.
+/// Usage: tioctl <path> <sid|notty|sctty>
+pub fn tioctl(shell: anytype, args: [][]u8) CmdError!void {
+    if (args.len != 3) return CmdError.InvalidNumberOfArguments;
+
+    const control = @import("../../tty/ioctl.zig");
+
+    const tnode = vfs.resolve(args[1]) catch {
+        utils.print_error(shell, "Invalid path: {s} does not exist", .{args[1]});
+        return CmdError.OtherError;
+    };
+    defer tnode.release();
+
+    const file = try translate_errno(shell, tnode.inode.open());
+    defer file.close() catch {};
+
+    var sid: i32 = -1;
+    const request: control.Request = if (std.mem.eql(u8, args[2], "sid"))
+        .TIOCGSID
+    else if (std.mem.eql(u8, args[2], "notty"))
+        .TIOCNOTTY
+    else if (std.mem.eql(u8, args[2], "sctty"))
+        .TIOCSCTTY
+    else
+        return CmdError.InvalidParameter;
+
+    _ = try translate_errno(
+        shell,
+        file.ioctl(@intFromEnum(request), @intFromPtr(&sid)),
+    );
+    if (request == .TIOCGSID) shell.print("sid {d}\n", .{sid});
+}

--- a/src/shell/default/builtins.zig
+++ b/src/shell/default/builtins.zig
@@ -979,3 +979,37 @@ pub fn session(shell: anytype, args: [][]u8) CmdError!void {
         shell.print(" no controlling terminal\n", .{});
     }
 }
+
+/// Start a session, POSIX setsid. The shell keeps it: a terminal opened
+/// afterwards becomes its controlling terminal.
+pub fn setsid(shell: anytype, _: [][]u8) CmdError!void {
+    const sid = @import("../../syscall/setsid.zig").do() catch |e| {
+        utils.print_error(shell, "setsid: {s}", .{@errorName(e)});
+        return CmdError.OtherError;
+    };
+    shell.print("session {d}\n", .{sid});
+}
+
+/// Open a path through the open syscall, acquiring the controlling terminal as
+/// userspace would. Leaves the descriptor open.
+/// Usage: ctty <path> [noctty]
+pub fn ctty(shell: anytype, args: [][]u8) CmdError!void {
+    if (args.len < 2 or args.len > 3) return CmdError.InvalidNumberOfArguments;
+
+    const open = @import("../../syscall/open.zig");
+
+    var path: [256]u8 = undefined;
+    if (args[1].len >= path.len) return CmdError.InvalidParameter;
+    @memcpy(path[0..args[1].len], args[1]);
+    path[args[1].len] = 0;
+
+    const no_ctty = args.len == 3 and std.mem.eql(u8, args[2], "noctty");
+    const fd = open.do(@ptrCast(&path), .{
+        .openMode = .read_write,
+        .no_controlling_tty = no_ctty,
+    }, .{}) catch |e| {
+        utils.print_error(shell, "open: {s}", .{@errorName(e)});
+        return CmdError.OtherError;
+    };
+    shell.print("fd {d}\n", .{fd});
+}

--- a/src/syscall/fork.zig
+++ b/src/syscall/fork.zig
@@ -25,7 +25,7 @@ pub fn do_raw() void {
     const new_task = task_set.create_task() catch |e| {
         current_task.ucontext.uc_mcontext.ebx = @intFromError(switch (e) {
             error.TooMuchProcesses => Errno.EAGAIN,
-            error.OutOfMemory => Errno.ENOMEM,
+            error.OutOfMemory, error.ENOMEM => Errno.ENOMEM,
         });
         return;
     };

--- a/src/syscall/getpgid.zig
+++ b/src/syscall/getpgid.zig
@@ -1,0 +1,15 @@
+const scheduler = @import("../task/scheduler.zig");
+const task_set = @import("../task/task_set.zig");
+const TaskDescriptor = @import("../task/task.zig").TaskDescriptor;
+
+pub const Id = 41;
+
+/// The process group of a task, POSIX getpgid. Zero means the caller.
+pub fn do(pid: TaskDescriptor.Pid) !TaskDescriptor.Pid {
+    const task = if (pid == 0)
+        scheduler.get_current_task()
+    else
+        task_set.get_task_descriptor(pid) orelse return error.ESRCH;
+
+    return task.pgid;
+}

--- a/src/syscall/getsid.zig
+++ b/src/syscall/getsid.zig
@@ -1,0 +1,15 @@
+const scheduler = @import("../task/scheduler.zig");
+const task_set = @import("../task/task_set.zig");
+const TaskDescriptor = @import("../task/task.zig").TaskDescriptor;
+
+pub const Id = 39;
+
+/// The session a task belongs to, POSIX getsid. Zero means the caller.
+pub fn do(pid: TaskDescriptor.Pid) !TaskDescriptor.Pid {
+    const task = if (pid == 0)
+        scheduler.get_current_task()
+    else
+        task_set.get_task_descriptor(pid) orelse return error.ESRCH;
+
+    return task.session.sid;
+}

--- a/src/syscall/ioctl.zig
+++ b/src/syscall/ioctl.zig
@@ -1,0 +1,11 @@
+const scheduler = @import("../task/scheduler.zig");
+const FileSet = @import("../task/file_set.zig");
+
+pub const Id = 42;
+
+/// Device control. Only for the three requests mlibc routes through ioctl:
+/// TIOCGPGRP, TIOCSPGRP and TIOCGSID. Everything else has its own syscall.
+pub fn do(fd: FileSet.Fd, request: u32, arg: usize) !usize {
+    const file = try scheduler.get_current_task().files.get(fd);
+    return file.ioctl(request, arg);
+}

--- a/src/syscall/open.zig
+++ b/src/syscall/open.zig
@@ -97,7 +97,6 @@ pub fn do(path: [*:0]const u8, flags: Flags, mode: Mode) Errno!FileSet.Fd {
         flags.close_on_exec or
         flags.close_on_fork or
         flags.directory or
-        flags.no_controlling_tty or
         flags.no_follow or
         flags.non_blocking or
         flags.tty_init)
@@ -109,5 +108,6 @@ pub fn do(path: [*:0]const u8, flags: Flags, mode: Mode) Errno!FileSet.Fd {
     if (flags.truncate) {
         try inode.truncate(0);
     }
+    @import("../tty/tty.zig").acquire_controlling(file, flags.no_controlling_tty);
     return try scheduler.get_current_task().files.add(file);
 }

--- a/src/syscall/setpgid.zig
+++ b/src/syscall/setpgid.zig
@@ -1,0 +1,34 @@
+const scheduler = @import("../task/scheduler.zig");
+const task_set = @import("../task/task_set.zig");
+const TaskDescriptor = @import("../task/task.zig").TaskDescriptor;
+
+pub const Id = 40;
+
+/// Put a task in a process group, POSIX setpgid. Zero means the caller for
+/// `pid`, and the task's own pid for `pgid`.
+///
+/// Only the caller or one of its children, within the caller's session, and
+/// never a session leader.
+pub fn do(pid: TaskDescriptor.Pid, pgid: TaskDescriptor.Pid) !void {
+    const caller = scheduler.get_current_task();
+
+    const task = if (pid == 0)
+        caller
+    else
+        task_set.get_task_descriptor(pid) orelse return error.ESRCH;
+
+    if (task != caller and task.parent != caller) return error.ESRCH;
+    if (task.session.sid == task.pid) return error.EPERM;
+    if (task.session != caller.session) return error.EPERM;
+
+    const target = if (pgid == 0) task.pid else pgid;
+    if (target < 0) return error.EINVAL;
+
+    // Joining an existing group means joining it inside this session.
+    if (target != task.pid) {
+        const leader = task_set.get_task_descriptor(target) orelse return error.EPERM;
+        if (leader.session != task.session) return error.EPERM;
+    }
+
+    task.pgid = target;
+}

--- a/src/syscall/setsid.zig
+++ b/src/syscall/setsid.zig
@@ -1,0 +1,23 @@
+const scheduler = @import("../task/scheduler.zig");
+const TaskDescriptor = @import("../task/task.zig").TaskDescriptor;
+const Session = @import("../task/session.zig");
+
+pub const Id = 38;
+
+/// Start a session, POSIX setsid.
+///
+/// The caller becomes session leader and sole member of a new process group,
+/// with no controlling terminal. A process group leader is refused, or its
+/// group would end up split across two sessions.
+pub fn do() !TaskDescriptor.Pid {
+    const task = scheduler.get_current_task();
+    if (task.pid == task.pgid) return error.EPERM;
+
+    // Before letting the old one go: failing here must leave the task as it was.
+    const session = try Session.create(task.pid);
+
+    task.session.release();
+    task.session = session;
+    task.pgid = task.pid;
+    return task.pid;
+}

--- a/src/task/session.zig
+++ b/src/task/session.zig
@@ -37,7 +37,7 @@ pub fn release(self: *Self) void {
     self.refs -= 1;
     if (self.refs != 0) return;
 
-    if (self.ctty) |terminal| self.disown(terminal);
+    self.hangup();
     allocator.destroy(self);
 }
 
@@ -50,6 +50,20 @@ pub fn claim(self: *Self, terminal: *TtyStruct, leader_pgid: TaskDescriptor.Pid)
     self.ctty = terminal;
     terminal.session = self;
     _ = terminal.set_foreground_pgid(leader_pgid);
+}
+
+/// Give the terminal up, hanging up the foreground group first.
+pub fn hangup(self: *Self) void {
+    const terminal = self.ctty orelse return;
+
+    if (terminal.foreground_pgid) |pgid| {
+        _ = @import("task_set.zig").send_signal_to_group(pgid, .{
+            .si_signo = .{ .valid = .SIGHUP },
+            .si_code = .SI_KERNEL,
+            .si_pid = 0,
+        });
+    }
+    self.disown(terminal);
 }
 
 /// Give the terminal back with no foreground group left to signal.

--- a/src/task/session.zig
+++ b/src/task/session.zig
@@ -1,0 +1,61 @@
+// A session and the terminal it may own. POSIX 11.1.3: a controlling terminal
+// belongs to a session and not to a task, so every task of a session sees the
+// same one and sees it change at the same time.
+
+const std = @import("std");
+
+const TaskDescriptor = @import("task.zig").TaskDescriptor;
+const TtyStruct = @import("../tty/TtyStruct.zig");
+
+const allocator = @import("../memory.zig").smallAlloc.allocator();
+
+const Self = @This();
+
+/// The pid of the task that created the session, and its name.
+sid: TaskDescriptor.Pid,
+
+/// The terminal this session controls, if it has claimed one.
+ctty: ?*TtyStruct = null,
+
+/// How many tasks belong to the session.
+refs: usize = 0,
+
+pub fn create(sid: TaskDescriptor.Pid) !*Self {
+    const self = allocator.create(Self) catch return error.ENOMEM;
+    self.* = .{ .sid = sid, .refs = 1 };
+    return self;
+}
+
+pub fn get_ref(self: *Self) *Self {
+    self.refs += 1;
+    return self;
+}
+
+/// The last task of a session takes its terminal with it.
+pub fn release(self: *Self) void {
+    std.debug.assert(self.refs > 0);
+    self.refs -= 1;
+    if (self.refs != 0) return;
+
+    if (self.ctty) |terminal| self.disown(terminal);
+    allocator.destroy(self);
+}
+
+/// Claim a terminal, POSIX 11.1.3: the foreground process group becomes that
+/// of the session leader. Fails when the terminal already answers to someone.
+pub fn claim(self: *Self, terminal: *TtyStruct, leader_pgid: TaskDescriptor.Pid) !void {
+    if (self.ctty != null) return error.EPERM;
+    if (terminal.session != null) return error.EPERM;
+
+    self.ctty = terminal;
+    terminal.session = self;
+    _ = terminal.set_foreground_pgid(leader_pgid);
+}
+
+/// Give the terminal back with no foreground group left to signal.
+pub fn disown(self: *Self, terminal: *TtyStruct) void {
+    if (self.ctty != terminal) return;
+    self.ctty = null;
+    terminal.session = null;
+    _ = terminal.set_foreground_pgid(null);
+}

--- a/src/task/task.zig
+++ b/src/task/task.zig
@@ -48,6 +48,10 @@ pub const TaskDescriptor = struct {
     pid: Pid,
     pgid: Pid,
 
+    /// Session this task belongs to, and through it the controlling terminal.
+    /// Shared with every other task of the session, inherited across fork.
+    session: *@import("session.zig"),
+
     owner: u32 = 0,
     cwd: *TNode,
     root: *TNode,
@@ -101,6 +105,7 @@ pub const TaskDescriptor = struct {
 
     pub fn deinit(self: *Self) void {
         self.status_wait_queue.unblock_all();
+        self.session.release();
 
         // Hot fix;
         // When a task exits, the callback are called only for the parent task.

--- a/src/task/task.zig
+++ b/src/task/task.zig
@@ -152,16 +152,7 @@ pub const TaskDescriptor = struct {
     /// group is hung up first, it was talking to a terminal it is about to lose.
     fn hangup_controlling_terminal(self: *Self) void {
         if (self.session.sid != self.pid) return;
-        const terminal = self.session.ctty orelse return;
-
-        if (terminal.foreground_pgid) |pgid| {
-            _ = task_set.send_signal_to_group(pgid, .{
-                .si_signo = .{ .valid = .SIGHUP },
-                .si_code = .SI_KERNEL,
-                .si_pid = 0,
-            });
-        }
-        self.session.disown(terminal);
+        self.session.hangup();
     }
 
     /// What a blocking call should do about whatever signal is waiting.

--- a/src/task/task.zig
+++ b/src/task/task.zig
@@ -147,6 +147,23 @@ pub const TaskDescriptor = struct {
         }
     }
 
+    /// POSIX 11.1.3: when the controlling process dies, its terminal leaves the
+    /// session, so that another session leader can take it. The foreground
+    /// group is hung up first, it was talking to a terminal it is about to lose.
+    fn hangup_controlling_terminal(self: *Self) void {
+        if (self.session.sid != self.pid) return;
+        const terminal = self.session.ctty orelse return;
+
+        if (terminal.foreground_pgid) |pgid| {
+            _ = task_set.send_signal_to_group(pgid, .{
+                .si_signo = .{ .valid = .SIGHUP },
+                .si_code = .SI_KERNEL,
+                .si_pid = 0,
+            });
+        }
+        self.session.disown(terminal);
+    }
+
     /// What a blocking call should do about whatever signal is waiting.
     pub const Disposition = enum { none, stop, interrupt };
 
@@ -180,6 +197,7 @@ pub const TaskDescriptor = struct {
     pub fn update_status(self: *Self, new_status_info: ?status_informations.Status) void {
         self.status_info = new_status_info;
         if (new_status_info) |s| {
+            if (s.transition == .Terminated) self.hangup_controlling_terminal();
             if (self.parent) |p| {
                 p.status_stack.add(&self.status_stack_process_node, s.transition);
                 p.status_wait_queue.try_unblock();

--- a/src/task/task_set.zig
+++ b/src/task/task_set.zig
@@ -2,6 +2,7 @@ const task = @import("task.zig");
 const TaskDescriptor = task.TaskDescriptor;
 const scheduler = @import("scheduler.zig");
 const vfs = @import("../fs/vfs.zig");
+const Session = @import("session.zig");
 
 const NTASK = 100; // todo: get this value from config
 
@@ -25,6 +26,7 @@ pub fn create_task() !*TaskDescriptor {
             .state = .Running,
             .root = hard_root,
             .cwd = hard_root,
+            .session = try Session.create(pid),
         };
     } else {
         new_task.* = .{
@@ -34,6 +36,7 @@ pub fn create_task() !*TaskDescriptor {
             .state = .Ready,
             .cwd = parent.cwd,
             .root = parent.root,
+            .session = parent.session.get_ref(),
         };
         new_task.next_sibling = parent.childs;
         parent.childs = new_task;

--- a/src/tty/TtyStruct.zig
+++ b/src/tty/TtyStruct.zig
@@ -43,6 +43,10 @@ read_timed_out: bool = false,
 /// Null until something claims the terminal, and nothing is signalled then.
 foreground_pgid: ?Pid = null,
 
+/// Session this terminal controls, POSIX 11.1.3. At most one, hence a single
+/// pointer.
+session: ?*@import("../task/session.zig") = null,
+
 // Input and reading, which the line discipline owns
 
 /// Feed bytes arriving from the hardware through the line discipline.

--- a/src/tty/ioctl.zig
+++ b/src/tty/ioctl.zig
@@ -13,8 +13,13 @@ pub const Request = enum(u32) {
     TCSETSF = 4,
 
     // Wired into options/posix/include/termios.h in mlibc, so not ours to pick.
+    /// Take this terminal as the controlling terminal of the calling session.
+    TIOCSCTTY = 0x540E,
     TIOCGPGRP = 0x540F,
     TIOCSPGRP = 0x5410,
+    /// Give up the controlling terminal.
+    TIOCNOTTY = 0x5422,
+    /// The session this terminal answers to, what tcgetsid reads.
     TIOCGSID = 0x5429,
 
     _,

--- a/src/tty/tty.zig
+++ b/src/tty/tty.zig
@@ -56,6 +56,21 @@ pub fn input_task(_: usize) u8 {
     }
 }
 
+/// Give a newly opened terminal to the session that opened it, POSIX 11.1.3.
+///
+/// A session leader with no controlling terminal, opening a terminal no session
+/// answers for, gets it. Called from open() rather than from the driver, the
+/// flags being what decides and only open() having them.
+pub fn acquire_controlling(file: *@import("../fs/file.zig"), no_ctty: bool) void {
+    if (no_ctty) return;
+
+    const terminal = @import("../drivers/tty/tty_cdev.zig").terminal_of(file) orelse return;
+    const task = scheduler.get_current_task();
+    if (task.session.sid != task.pid) return;
+
+    task.session.claim(terminal, task.pgid) catch {};
+}
+
 pub fn get_tty() *TtyStruct {
     return &tty_array[current_tty];
 }

--- a/src/userspace.poc.zig
+++ b/src/userspace.poc.zig
@@ -273,3 +273,75 @@ export fn userland_io() linksection(".userspace") void {
     putstr_fd(fd, "BBBBBBBBBBBBBBBBBBBBBB\n");
     _ = syscall(.exit, .{0});
 }
+
+/// Sessions and the controlling terminal, POSIX 11.1.3, from userspace. The
+/// kernel shell cannot show this: the only session leader it has is itself.
+export fn userland_ctty() linksection(".userspace") void {
+    const path = "/dev/tty0";
+    const flags = open.Flags{ .openMode = .read_write };
+
+    // setsid refuses a process group leader, and the spawned job is one.
+    putstr("job pid ");
+    putnbr(syscall(.getpid, .{}));
+    putstr(" pgid ");
+    putnbr(syscall(.getpgid, .{0}));
+    putstr("\n");
+
+    const leader = syscall(.fork, .{});
+    if (leader == 0) {
+        const sid = syscall(.setsid, .{});
+        putstr("leader pid ");
+        putnbr(syscall(.getpid, .{}));
+        putstr(" pgid ");
+        putnbr(syscall(.getpgid, .{0}));
+        putstr(" session ");
+        putnbr(sid);
+
+        const fd = syscall(.open, .{ path.ptr, flags, open.Mode{} });
+        putstr(" fd ");
+        putnbr(fd);
+
+        var owner: i32 = -1;
+        _ = syscall(.ioctl, .{ fd, TIOCGSID, &owner });
+        putstr(" tiocgsid ");
+        putnbr(owner);
+        putstr("\n");
+
+        // In the foreground group, so the leader's death should hang it up.
+        if (syscall(.fork, .{}) == 0) {
+            putstr("fg child pid ");
+            putnbr(syscall(.getpid, .{}));
+            putstr(" pgid ");
+            putnbr(syscall(.getpgid, .{0}));
+            putstr("\n");
+            _ = syscall(.sleep, .{1500});
+            putstr("BAD: foreground child outlived the hangup\n");
+            _ = syscall(.exit, .{1});
+        }
+
+        _ = syscall(.sleep, .{300});
+        _ = syscall(.exit, .{0});
+    }
+
+    _ = syscall(.sleep, .{2500});
+
+    // A second session, to see whether the terminal came back.
+    if (syscall(.fork, .{}) == 0) {
+        _ = syscall(.setsid, .{});
+        const fd = syscall(.open, .{ path.ptr, flags, open.Mode{} });
+
+        var owner: i32 = -1;
+        const answer = syscall(.ioctl, .{ fd, TIOCGSID, &owner });
+        if (answer == 0 and owner == syscall(.getsid, .{0}))
+            putstr("terminal released and taken again\n")
+        else
+            putstr("BAD: terminal still answers to the dead session\n");
+
+        _ = syscall(.exit, .{0});
+    }
+
+    _ = syscall(.sleep, .{1000});
+    _ = syscall(.exit, .{0});
+}
+
+const TIOCGSID: u32 = 0x5429;


### PR DESCRIPTION
POSIX 11.1.3 puts the controlling terminal on the session, not the task.
`task/session.zig` is new; inherited across fork, released with the last task.
`setsid`, `getsid`, `setpgid` and `getpgid` come with it.

**Acquisition is in `syscall/open.zig`**, not the driver's `open`: POSIX makes it a property of `open()`, and that is the only place that knows the flags.
Pushing them down would have changed `Inode.VTable.open`'s signature.
`open` no longer panics on `O_NOCTTY`; the others still do.

**`/dev/tty`**, major 5, resolved per open to the caller's controlling terminal.
A session without one gets ENXIO, which needed `fs/character.zig` to stop flattening driver errors to EIO: `DeviceNotFound` now maps to ENXIO, `OutOfMemory` to ENOMEM, `PermissionDenied` to EPERM.
`Inode.Error.open` already listed ENXIO and never reached it.

**Hangup**: the controlling process dying frees the terminal for another leader, the foreground group getting SIGHUP first.

**TIOCSCTTY, TIOCNOTTY, TIOCGSID** with a deliberately narrow `ioctl` syscall: the numbers are the ones in mlibc. Everything else has its own call.