### PR TITLE
terminal access control

### DIFF
--- a/src/drivers/tty/tty_cdev.zig
+++ b/src/drivers/tty/tty_cdev.zig
@@ -13,6 +13,8 @@ const tty = @import("../../tty/tty.zig");
 const TtyStruct = @import("../../tty/TtyStruct.zig");
 const termios = @import("../../tty/termios.zig");
 const control = @import("../../tty/ioctl.zig");
+const job_control = @import("../../tty/job_control.zig");
+const task_set = @import("../../task/task_set.zig");
 const scheduler = @import("../../task/scheduler.zig");
 const TaskDescriptor = @import("../../task/task.zig").TaskDescriptor;
 
@@ -54,12 +56,19 @@ pub fn terminal_of(file: *File) ?*TtyStruct {
     return terminal(file);
 }
 
+// Access control belongs on the descriptor path, POSIX 11.1.4: kernel output
+// has no process group.
+
 fn read(file: *File, buffer: []u8) File.Error.read!usize {
-    return terminal(file).read(buffer);
+    const terminal_ = terminal(file);
+    try job_control.check_read(terminal_, scheduler.get_current_task());
+    return terminal_.read(buffer);
 }
 
 fn write(file: *File, data: []const u8) File.Error.write!usize {
-    return terminal(file).write(data);
+    const terminal_ = terminal(file);
+    try job_control.check_write(terminal_, scheduler.get_current_task());
+    return terminal_.write(data);
 }
 
 /// The control requests POSIX reaches through tcgetattr and tcsetattr. With no
@@ -73,9 +82,32 @@ fn ioctl(file: *File, request: u32, arg: usize) File.Error.ioctl!usize {
             out.* = termios.to_abi(terminal_.config);
         },
         .TCSETS, .TCSETSW, .TCSETSF => |request_| {
+            try job_control.check_control(terminal_, scheduler.get_current_task());
             const new: *const termios.abi.Termios = @ptrFromInt(arg);
             if (request_ == .TCSETSF) terminal_.input_buffer.clear();
             terminal_.set_termios(termios.from_abi(new.*));
+        },
+        .TIOCGPGRP => {
+            // POSIX tcgetpgrp: only the caller's own terminal answers.
+            const task = scheduler.get_current_task();
+            if (task.session.ctty != terminal_) return error.ENOTTY;
+
+            const out: *TaskDescriptor.Pid = @ptrFromInt(arg);
+            // No foreground group is reported as a group id that matches none.
+            out.* = terminal_.foreground_pgid orelse std.math.maxInt(TaskDescriptor.Pid);
+        },
+        .TIOCSPGRP => {
+            const task = scheduler.get_current_task();
+            if (task.session.ctty != terminal_) return error.ENOTTY;
+            try job_control.check_control(terminal_, task);
+
+            const wanted: *const TaskDescriptor.Pid = @ptrFromInt(arg);
+            if (wanted.* <= 0) return error.EINVAL;
+            // A group of another session would leave the terminal unreachable.
+            const member = task_set.find_in_group(wanted.*) orelse return error.EPERM;
+            if (member.session != task.session) return error.EPERM;
+
+            _ = terminal_.set_foreground_pgid(wanted.*);
         },
         .TIOCGSID => {
             // POSIX tcgetsid: a terminal no session answers for is not the

--- a/src/fs/file.zig
+++ b/src/fs/file.zig
@@ -40,6 +40,8 @@ pub const Error = struct {
         EPERM,
         ENOSPC,
         EINVAL,
+        /// A write cut short by a signal, SIGTTOU among them.
+        EINTR,
     };
     pub const readdir = error{
         EBUSY,
@@ -53,6 +55,8 @@ pub const Error = struct {
         EINVAL,
         EIO,
         EPERM,
+        /// tcsetattr from a background group raises SIGTTOU and gives up.
+        EINTR,
     };
     pub const seek = error{
         EOVERFLOW,

--- a/src/shell/default/builtins.zig
+++ b/src/shell/default/builtins.zig
@@ -370,6 +370,7 @@ pub fn demo(shell: anytype, args: [][]u8) CmdError!void {
         "fork",
         "io",
         "ctty",
+        "jobctl",
     };
 
     if (args.len != 2) {

--- a/src/task/task_set.zig
+++ b/src/task/task_set.zig
@@ -94,3 +94,25 @@ pub fn send_signal_to_group(pgid: TaskDescriptor.Pid, sig: @import("signal.zig")
     }
     return sent;
 }
+
+/// Whether a process group has nobody left outside it to restart it. POSIX
+/// XBD 3: every member's parent is in the group itself or outside its session.
+pub fn is_orphaned_group(pgid: TaskDescriptor.Pid) bool {
+    for (list) |entry| {
+        const member = entry orelse continue;
+        if (member.pgid != pgid) continue;
+
+        const parent = member.parent orelse continue;
+        if (parent.pgid != pgid and parent.session == member.session) return false;
+    }
+    return true;
+}
+
+/// Any task of a process group, or null when the group holds none.
+pub fn find_in_group(pgid: TaskDescriptor.Pid) ?*TaskDescriptor {
+    for (list) |entry| {
+        const member = entry orelse continue;
+        if (member.pgid == pgid) return member;
+    }
+    return null;
+}

--- a/src/tty/job_control.zig
+++ b/src/tty/job_control.zig
@@ -1,0 +1,71 @@
+// Who may read from and write to a terminal, POSIX 11.1.4. Only the caller's
+// own controlling terminal is governed; any other is an ordinary file.
+
+const TtyStruct = @import("TtyStruct.zig");
+const TaskDescriptor = @import("../task/task.zig").TaskDescriptor;
+const task_set = @import("../task/task_set.zig");
+const signal = @import("../task/signal.zig");
+
+/// EINTR says a signal was raised and the operation gave up; EIO says the
+/// caller is out of reach of the terminal and no signal was raised.
+pub const Error = error{ EIO, EINTR };
+
+/// A signal that would be thrown away rather than acted on. POSIX weighs this
+/// before stopping anyone.
+fn would_be_lost(task: *TaskDescriptor, id: signal.Id) bool {
+    if (task.signalManager.get_action(id).sa_handler == signal.SIG_IGN) return true;
+    const bit = @as(signal.SigSet, 1) << @intCast(@intFromEnum(id));
+    return task.ucontext.uc_sigmask & bit != 0;
+}
+
+fn raise(task: *TaskDescriptor, id: signal.Id) void {
+    _ = task_set.send_signal_to_group(task.pgid, .{
+        .si_signo = .{ .valid = id },
+        .si_code = .SI_KERNEL,
+        .si_pid = 0,
+    });
+}
+
+/// Whether this terminal governs the caller at all, and whether the caller is
+/// already in the foreground. Null means there is nothing to check.
+fn background(terminal: *TtyStruct, task: *TaskDescriptor) bool {
+    if (task.session.ctty != terminal) return false;
+    const foreground = terminal.foreground_pgid orelse return false;
+    return task.pgid != foreground;
+}
+
+/// Reading from the background stops the group, POSIX 11.1.4. A group that
+/// would not act on SIGTTIN, or that nothing could restart, gets EIO instead.
+pub fn check_read(terminal: *TtyStruct, task: *TaskDescriptor) Error!void {
+    if (!background(terminal, task)) return;
+
+    if (would_be_lost(task, .SIGTTIN)) return error.EIO;
+    if (task_set.is_orphaned_group(task.pgid)) return error.EIO;
+
+    raise(task, .SIGTTIN);
+    return error.EINTR;
+}
+
+/// Writing from the background only stops the group under TOSTOP. Where a read
+/// refuses, a write goes through: the asymmetry is in the spec.
+pub fn check_write(terminal: *TtyStruct, task: *TaskDescriptor) Error!void {
+    if (!background(terminal, task)) return;
+    if (!terminal.config.c_lflag.TOSTOP) return;
+    if (would_be_lost(task, .SIGTTOU)) return;
+    if (task_set.is_orphaned_group(task.pgid)) return error.EIO;
+
+    raise(task, .SIGTTOU);
+    return error.EINTR;
+}
+
+/// Setting terminal parameters is treated as a write with TOSTOP always set,
+/// POSIX 11.1.4: tcsetattr, tcflush, tcflow, tcdrain, tcsendbreak, tcsetpgrp
+/// and tcsetwinsize.
+pub fn check_control(terminal: *TtyStruct, task: *TaskDescriptor) Error!void {
+    if (!background(terminal, task)) return;
+    if (would_be_lost(task, .SIGTTOU)) return;
+    if (task_set.is_orphaned_group(task.pgid)) return error.EIO;
+
+    raise(task, .SIGTTOU);
+    return error.EINTR;
+}

--- a/src/userspace.poc.zig
+++ b/src/userspace.poc.zig
@@ -345,3 +345,47 @@ export fn userland_ctty() linksection(".userspace") void {
 }
 
 const TIOCGSID: u32 = 0x5429;
+
+/// Terminal access control, POSIX 11.1.4, from userspace. A child in a group of
+/// its own reads, and SIGTTIN stops it.
+export fn userland_jobctl() linksection(".userspace") void {
+    const path = "/dev/tty0";
+    const flags = open.Flags{ .openMode = .read_write };
+
+    // setsid refuses a process group leader, hence the extra fork.
+    if (syscall(.fork, .{}) != 0) {
+        _ = syscall(.sleep, .{3000});
+        _ = syscall(.exit, .{0});
+    }
+
+    _ = syscall(.setsid, .{});
+    _ = syscall(.open, .{ path.ptr, flags, open.Mode{} });
+
+    if (syscall(.fork, .{}) == 0) {
+        // A group of its own is a background group.
+        _ = syscall(.setpgid, .{ 0, 0 });
+        _ = syscall(.sleep, .{200});
+
+        var scratch: [1]u8 = undefined;
+        const read_bytes = syscall(.read, .{ 0, &scratch, 1 });
+        putstr("BAD: background read returned ");
+        putnbr(read_bytes);
+        putstr("\n");
+        _ = syscall(.exit, .{1});
+    }
+
+    var status: u32 = 0;
+    const who = syscall(.waitpid, .{ -1, &status, wait.WaitOptions{ .WUNTRACED = true } });
+
+    putstr("child ");
+    putnbr(who);
+    putstr(" status ");
+    putnbr(status & 0xff);
+    putstr(" signal ");
+    putnbr((status >> 8) & 0xff);
+    putstr("\n");
+
+    _ = syscall(.exit, .{0});
+}
+
+const wait = @import("task/wait.zig");


### PR DESCRIPTION
POSIX 11.1.4, in `tty/job_control.zig`.
A background group reading its controlling terminal gets SIGTTIN; writing only raises SIGTTOU under TOSTOP.

The asymmetry is in the spec and worth a look in review: where a read refuses with EIO when the signal would be ignored or blocked, a write goes through.
An orphaned group gets EIO rather than being stopped, nothing could restart it.

`tcgetpgrp` and `tcsetpgrp` come with it. The checks sit on the descriptor path: kernel output has no process group.