### PR TITLE
tty flow control

### DIFF
--- a/src/drivers/tty/tty_cdev.zig
+++ b/src/drivers/tty/tty_cdev.zig
@@ -68,6 +68,9 @@ fn read(file: *File, buffer: []u8) File.Error.read!usize {
 fn write(file: *File, data: []const u8) File.Error.write!usize {
     const terminal_ = terminal(file);
     try job_control.check_write(terminal_, scheduler.get_current_task());
+    // Only a process waits on a suspended terminal; kernel output must not
+    // block behind a Ctrl-S.
+    try terminal_.wait_for_output();
     return terminal_.write(data);
 }
 
@@ -87,6 +90,29 @@ fn ioctl(file: *File, request: u32, arg: usize) File.Error.ioctl!usize {
             if (request_ == .TCSETSF) terminal_.input_buffer.clear();
             terminal_.set_termios(termios.from_abi(new.*));
         },
+        .TCFLSH => {
+            try job_control.check_control(terminal_, scheduler.get_current_task());
+            switch (@as(control.FlushQueue, @enumFromInt(arg))) {
+                // Nothing is ever pending on the way out: a console has
+                // transmitted a byte by the time write returns. These become
+                // real with a line that can be busy.
+                .OUTPUT => {},
+                .INPUT, .BOTH => terminal_.input_buffer.clear(),
+                else => return error.EINVAL,
+            }
+        },
+        .TCXONC => {
+            try job_control.check_control(terminal_, scheduler.get_current_task());
+            switch (@as(control.FlowAction, @enumFromInt(arg))) {
+                .OUTPUT_OFF => terminal_.set_output_stopped(true),
+                .OUTPUT_ON => terminal_.set_output_stopped(false),
+                // Sending a character to an end a console does not have.
+                .INPUT_OFF, .INPUT_ON => {},
+                else => return error.EINVAL,
+            }
+        },
+        // Both wait on the hardware, and a console keeps nothing waiting.
+        .TCDRAIN, .TCSBRK => try job_control.check_control(terminal_, scheduler.get_current_task()),
         .TIOCGPGRP => {
             // POSIX tcgetpgrp: only the caller's own terminal answers.
             const task = scheduler.get_current_task();

--- a/src/syscall/tcdrain.zig
+++ b/src/syscall/tcdrain.zig
@@ -1,0 +1,10 @@
+const scheduler = @import("../task/scheduler.zig");
+const FileSet = @import("../task/file_set.zig");
+const control = @import("../tty/ioctl.zig");
+
+pub const Id = 45;
+
+pub fn do(fd: FileSet.Fd, arg: u32) !void {
+    const file = try scheduler.get_current_task().files.get(fd);
+    _ = try file.ioctl(@intFromEnum(control.Request.TCDRAIN), arg);
+}

--- a/src/syscall/tcflow.zig
+++ b/src/syscall/tcflow.zig
@@ -1,0 +1,10 @@
+const scheduler = @import("../task/scheduler.zig");
+const FileSet = @import("../task/file_set.zig");
+const control = @import("../tty/ioctl.zig");
+
+pub const Id = 44;
+
+pub fn do(fd: FileSet.Fd, arg: u32) !void {
+    const file = try scheduler.get_current_task().files.get(fd);
+    _ = try file.ioctl(@intFromEnum(control.Request.TCXONC), arg);
+}

--- a/src/syscall/tcflush.zig
+++ b/src/syscall/tcflush.zig
@@ -1,0 +1,10 @@
+const scheduler = @import("../task/scheduler.zig");
+const FileSet = @import("../task/file_set.zig");
+const control = @import("../tty/ioctl.zig");
+
+pub const Id = 43;
+
+pub fn do(fd: FileSet.Fd, arg: u32) !void {
+    const file = try scheduler.get_current_task().files.get(fd);
+    _ = try file.ioctl(@intFromEnum(control.Request.TCFLSH), arg);
+}

--- a/src/syscall/tcsendbreak.zig
+++ b/src/syscall/tcsendbreak.zig
@@ -1,0 +1,10 @@
+const scheduler = @import("../task/scheduler.zig");
+const FileSet = @import("../task/file_set.zig");
+const control = @import("../tty/ioctl.zig");
+
+pub const Id = 46;
+
+pub fn do(fd: FileSet.Fd, arg: u32) !void {
+    const file = try scheduler.get_current_task().files.get(fd);
+    _ = try file.ioctl(@intFromEnum(control.Request.TCSBRK), arg);
+}

--- a/src/tty/TtyStruct.zig
+++ b/src/tty/TtyStruct.zig
@@ -39,6 +39,13 @@ read_queue: wait_queue.WaitQueue(.{ .predicate = input_ready }) = .{},
 /// Raised when the VTIME timer fires, cleared when a read starts waiting again.
 read_timed_out: bool = false,
 
+/// Output suspended by the STOP character or by tcflow, POSIX 11.2.2. A writer
+/// waits rather than losing what it had to say.
+output_stopped: bool = false,
+
+/// Writers held back while output is suspended.
+output_queue: wait_queue.WaitQueue(.{ .predicate = output_ready }) = .{},
+
 /// Process group the control characters of this terminal signal, POSIX 11.1.2.
 /// Null until something claims the terminal, and nothing is signalled then.
 foreground_pgid: ?Pid = null,
@@ -59,6 +66,27 @@ pub fn input(self: *Self, s: []const u8) void {
 fn input_ready(_: *void, data: ?*void) bool {
     const self: *Self = @ptrCast(@alignCast(data.?));
     return self.read_timed_out or n_tty.has_input(self);
+}
+
+fn output_ready(_: *void, data: ?*void) bool {
+    const self: *Self = @ptrCast(@alignCast(data.?));
+    return !self.output_stopped;
+}
+
+/// Suspend or resume output, POSIX 11.2.2. Resuming wakes whoever was waiting.
+pub fn set_output_stopped(self: *Self, stopped: bool) void {
+    self.output_stopped = stopped;
+    if (!stopped) self.output_queue.try_unblock();
+}
+
+/// Wait until output is allowed again. Interruptible: a job frozen by a STOP
+/// character must still be killable.
+pub fn wait_for_output(self: *Self) error{EINTR}!void {
+    while (self.output_stopped)
+        self.output_queue.block(
+            @import("../task/scheduler.zig").get_current_task(),
+            @ptrCast(self),
+        ) catch return error.EINTR;
 }
 
 /// Read from the terminal, suitable for std.io.Reader.

--- a/src/tty/ioctl.zig
+++ b/src/tty/ioctl.zig
@@ -11,6 +11,14 @@ pub const Request = enum(u32) {
     TCSETSW = 3,
     /// Apply once the output has drained, discarding pending input.
     TCSETSF = 4,
+    /// Throw away input, output, or both.
+    TCFLSH = 5,
+    /// Suspend or resume a direction of the line.
+    TCXONC = 6,
+    /// Wait for the output to be transmitted.
+    TCDRAIN = 7,
+    /// Send a break.
+    TCSBRK = 8,
 
     // Wired into options/posix/include/termios.h in mlibc, so not ours to pick.
     /// Take this terminal as the controlling terminal of the calling session.
@@ -22,6 +30,26 @@ pub const Request = enum(u32) {
     /// The session this terminal answers to, what tcgetsid reads.
     TIOCGSID = 0x5429,
 
+    _,
+};
+
+/// Which queue tcflush empties, POSIX 11.2. The values are the ones mlibc's
+/// shared header gives TCIFLUSH, TCOFLUSH and TCIOFLUSH.
+pub const FlushQueue = enum(u32) {
+    INPUT = 0,
+    OUTPUT = 1,
+    BOTH = 2,
+    _,
+};
+
+/// What tcflow suspends or resumes, POSIX 11.2.
+pub const FlowAction = enum(u32) {
+    OUTPUT_OFF = 0,
+    OUTPUT_ON = 1,
+    /// Send a STOP character, asking the other end to stop sending.
+    INPUT_OFF = 2,
+    /// Send a START character.
+    INPUT_ON = 3,
     _,
 };
 

--- a/src/tty/ldisc/n_tty.zig
+++ b/src/tty/ldisc/n_tty.zig
@@ -61,9 +61,33 @@ fn raise_signal(tty: *TtyStruct, c: u8, id: signal.Id) void {
     });
 }
 
+/// The START and STOP characters, POSIX 11.2.2 IXON. They control output and
+/// are not themselves input, so they never reach a reader.
+///
+/// IXANY makes any character restart output, which is what makes a terminal
+/// frozen by a stray Ctrl-S recoverable by typing anything at all.
+fn flow_control(tty: *TtyStruct, c: u8) bool {
+    if (!tty.config.c_iflag.IXON) return false;
+
+    if (c == cc(tty, .VSTOP)) {
+        tty.set_output_stopped(true);
+        return true;
+    }
+    if (c == cc(tty, .VSTART)) {
+        tty.set_output_stopped(false);
+        return true;
+    }
+    if (tty.output_stopped and tty.config.c_iflag.IXANY) {
+        tty.set_output_stopped(false);
+        return true;
+    }
+    return false;
+}
+
 fn receive_char(tty: *TtyStruct, raw: u8) void {
     const c = input_processing(tty, raw) orelse return;
 
+    if (flow_control(tty, c)) return;
     if (signal_char(tty, c)) |id| return raise_signal(tty, c, id);
 
     if (!tty.config.c_lflag.ICANON) {

--- a/src/tty/termios.zig
+++ b/src/tty/termios.zig
@@ -118,7 +118,8 @@ pub const lflags = packed struct {
 };
 
 pub const termios = struct {
-    c_iflag: iflags = .{ .BRKINT = true, .ICRNL = true },
+    // IXON on by default: Ctrl-S and Ctrl-Q are what every terminal does.
+    c_iflag: iflags = .{ .BRKINT = true, .ICRNL = true, .IXON = true },
     c_oflag: oflags = .{ .OPOST = true, .ONLCR = true },
     c_cflag: cflags = .{ .CREAD = true, .CLOCAL = true },
     c_lflag: lflags = .{ .ISIG = true, .ICANON = true, .ECHO = true, .IEXTEN = true, .ECHOE = true, .ECHOK = true },


### PR DESCRIPTION
IXON: the STOP character suspends output and START resumes it, IXANY letting any character do the resuming. A write waits rather than losing what it had to say. IXON is on by default, as on every terminal.

tcflush, tcflow, tcdrain and tcsendbreak with it. The output side of each is a no-op: a console has transmitted a byte by the time write returns, so nothing is ever pending. They become real with a line that can be busy.