### PR TITLE
ELF loader

### DIFF
--- a/src/shell/default/builtins.zig
+++ b/src/shell/default/builtins.zig
@@ -817,8 +817,13 @@ pub fn mknod(shell: anytype, args: [][]u8) CmdError!void {
     };
 
     const inode = try translate_errno(shell, switch (args[2][0]) {
-        'b' => dir_tnode.inode.superblock.create_inode(0, 0, .{ .type = .Block }, .{ .Block = .{ .major = major, .minor = minor } }),
-        'c' => dir_tnode.inode.superblock.create_inode(0, 0, .{ .type = .Character }, .{ .Character = .{ .major = major, .minor = minor } }),
+        'b' => dir_tnode.inode.superblock.create_inode(0, 0, .{ .type = .Block }, .{
+            .Block = .{ .major = major, .minor = minor },
+        }),
+        'c' => dir_tnode.inode.superblock.create_inode(0, 0, .{ .type = .Character }, .{ .Character = .{
+            .major = major,
+            .minor = minor,
+        } }),
         else => {
             utils.print_error(shell, "Invalid node type", .{});
             return CmdError.OtherError;
@@ -1080,4 +1085,31 @@ pub fn hangup(shell: anytype, args: [][]u8) CmdError!void {
 
     terminal.hangup();
     shell.print("tty{d} hung up: {}\n", .{ terminal.index, terminal.hung_up });
+}
+
+pub fn test_elf(shell: anytype, args: [][]u8) CmdError!void {
+    const Elf = @import("../../task/elf.zig");
+    if (args.len < 2) return CmdError.InvalidNumberOfArguments;
+
+    const tnode = vfs.resolve(args[1]) catch return CmdError.OtherError;
+    const heapAlloc = @import("../../memory.zig").bigAlloc.allocator();
+    const data = heapAlloc.alloc(
+        u8,
+        std.math.cast(usize, tnode.inode.size) orelse return CmdError.OtherError,
+    ) catch return CmdError.OtherError;
+    defer heapAlloc.free(data);
+
+    const file = tnode.inode.open() catch return CmdError.OtherError;
+    defer file.close() catch {};
+
+    if ((file.pread(0, data) catch return CmdError.OtherError) != data.len) {
+        return CmdError.OtherError;
+    }
+
+    Elf.validate(data) catch |e| {
+        utils.print_error(shell, "Invalid ELF file: {s}", .{@errorName(e)});
+        return CmdError.OtherError;
+    };
+
+    shell.writer.print("ELF file {s} is valid\n", .{args[1]}) catch {};
 }

--- a/src/shell/default/builtins.zig
+++ b/src/shell/default/builtins.zig
@@ -1087,24 +1087,84 @@ pub fn hangup(shell: anytype, args: [][]u8) CmdError!void {
     shell.print("tty{d} hung up: {}\n", .{ terminal.index, terminal.hung_up });
 }
 
+// test_load_entry is not a CLI builtin, it's used by test_elf to spawn a new task that loads an ELF file and
+// reports back the loaded regions and entrypoint. All shell printing happens back in test_elf, after waitpid()
+const RegionInfo = struct { begin: usize, end: usize, r: bool, w: bool };
+const TestLoadResult = union(enum) {
+    ok: struct { entry: usize, phdr_vaddr: usize, regions: []RegionInfo },
+    err: @import("../../task/elf.zig").Error,
+};
+const TestLoadRequest = struct { data: []u8, result: TestLoadResult = undefined };
+fn test_load_entry(data_ptr: usize) u8 {
+    const heapAlloc = @import("../../memory.zig").bigAlloc.allocator();
+    const smallAlloc = @import("../../memory.zig").smallAlloc.allocator();
+    const Elf = @import("../../task/elf.zig");
+    const RegionSet = @import("../../memory/region_set.zig").RegionSet;
+    const task = @import("../../task/task.zig");
+    const paging = @import("../../memory/paging.zig");
+
+    const req: *TestLoadRequest = @ptrFromInt(data_ptr);
+    const data = req.data;
+
+    const self = @import("../../task/scheduler.zig").get_current_task();
+    self.init_vm() catch {
+        heapAlloc.free(data);
+        req.result = .{ .err = error.LoadFailed };
+        task.exit(1);
+    };
+    const vm = self.vm.?;
+
+    const image = Elf.load(vm, data) catch |e| {
+        heapAlloc.free(data);
+        req.result = .{ .err = e };
+        task.exit(1);
+    };
+
+    heapAlloc.free(data); // fully consumed: load() already copied every PT_LOAD's bytes into vm
+
+    var count: usize = 0;
+    var it = vm.regions.list.first;
+    while (it) |node| : (it = node.next) count += 1;
+
+    const regions = smallAlloc.alloc(RegionInfo, count) catch @panic("oom collecting regions");
+    it = vm.regions.list.first;
+    var i: usize = 0;
+    while (it) |node| : ({
+        it = node.next;
+        i += 1;
+    }) {
+        const r = &@as(*RegionSet.ListNode, @fieldParentPtr("node", node)).data;
+        regions[i] = .{
+            .begin = r.begin * paging.page_size,
+            .end = (r.begin + r.len) * paging.page_size,
+            .r = r.flags.read,
+            .w = r.flags.write,
+        };
+    }
+
+    req.result = .{ .ok = .{ .entry = image.entry, .phdr_vaddr = image.phdr_vaddr, .regions = regions } };
+    task.exit(0);
+}
+
 pub fn test_elf(shell: anytype, args: [][]u8) CmdError!void {
+    const heapAlloc = @import("../../memory.zig").bigAlloc.allocator();
+    const smallAlloc = @import("../../memory.zig").smallAlloc.allocator();
     const Elf = @import("../../task/elf.zig");
     if (args.len < 2) return CmdError.InvalidNumberOfArguments;
 
     const tnode = vfs.resolve(args[1]) catch return CmdError.OtherError;
-    const heapAlloc = @import("../../memory.zig").bigAlloc.allocator();
+    defer tnode.release();
     const data = heapAlloc.alloc(
         u8,
         std.math.cast(usize, tnode.inode.size) orelse return CmdError.OtherError,
     ) catch return CmdError.OtherError;
-    defer heapAlloc.free(data);
+    errdefer heapAlloc.free(data);
 
     const file = tnode.inode.open() catch return CmdError.OtherError;
     defer file.close() catch {};
 
-    if ((file.pread(0, data) catch return CmdError.OtherError) != data.len) {
+    if ((file.pread(0, data) catch return CmdError.OtherError) != data.len)
         return CmdError.OtherError;
-    }
 
     Elf.validate(data) catch |e| {
         utils.print_error(shell, "Invalid ELF file: {s}", .{@errorName(e)});
@@ -1112,4 +1172,26 @@ pub fn test_elf(shell: anytype, args: [][]u8) CmdError!void {
     };
 
     shell.writer.print("ELF file {s} is valid\n", .{args[1]}) catch {};
+
+    // Create a task to load the elf and print the mapped regions
+    const req = smallAlloc.create(TestLoadRequest) catch return CmdError.OtherError;
+    defer smallAlloc.destroy(req);
+    req.* = .{ .data = data };
+
+    const new_task = @import("../../task/task_set.zig").create_task() catch @panic("cannot create task");
+    new_task.spawn(&test_load_entry, @intFromPtr(req)) catch @panic("spawn failed");
+    utils.waitpid(shell, new_task.pid);
+
+    switch (req.result) {
+        .ok => |ok| {
+            defer smallAlloc.free(ok.regions);
+            shell.writer.print("entry=0x{x} phdr_vaddr=0x{x}\n", .{ ok.entry, ok.phdr_vaddr }) catch {};
+            for (ok.regions) |r| {
+                shell.writer.print("region [0x{x}, 0x{x}) r={} w={}\n", .{ r.begin, r.end, r.r, r.w }) catch {};
+            }
+        },
+        .err => |e| {
+            utils.print_error(shell, "load failed: {s}", .{@errorName(e)});
+        },
+    }
 }

--- a/src/task/elf.zig
+++ b/src/task/elf.zig
@@ -1,5 +1,11 @@
 const std = @import("std");
 const paging = @import("../memory/paging.zig");
+const regions = @import("../memory/regions.zig");
+const RegionSet = @import("../memory/region_set.zig").RegionSet;
+const VirtualSpace = @import("../memory/virtual_space.zig").VirtualSpace;
+
+const Ehdr = std.elf.Ehdr; // std.elf.Ehdr -> std.elf.Elf32_Ehdr on i386
+const Phdr = std.elf.Phdr; // std.elf.Phdr -> std.elf.Elf32_Phdr on i386
 
 /// Everything a sysv i386 '_start' (and later a dynamic linker) needs to bootstrap a process.
 /// 'phdr_vaddr' is the runtime address of the program header table when a PT_LOAD segment maps it,
@@ -20,13 +26,6 @@ pub const Error = error{
     LoadFailed,
 };
 
-const Ehdr = std.elf.Ehdr; // std.elf.Ehdr -> std.elf.Elf32_Ehdr on i386
-const Phdr = std.elf.Phdr; // std.elf.Phdr -> std.elf.Elf32_Phdr on i386
-
-const regions = @import("../memory/regions.zig");
-const RegionSet = @import("../memory/region_set.zig").RegionSet;
-const VirtualSpace = @import("../memory/virtual_space.zig").VirtualSpace;
-
 /// Returns true if the range [offset, offset + len[ is within [0, total[
 inline fn in_bounds(offset: usize, len: usize, total: usize) bool {
     // check for overflow
@@ -34,9 +33,9 @@ inline fn in_bounds(offset: usize, len: usize, total: usize) bool {
     return end <= total;
 }
 
-fn parse_header(data: []const u8) !Ehdr {
+fn parse_header(data: []const u8) Error!Ehdr {
     if (data.len < @sizeOf(Ehdr)) return Error.InvalidElf;
-    const header: Ehdr = @as(*const Ehdr, @ptrCast(@alignCast(data.ptr))).*;
+    const header = std.mem.bytesToValue(Ehdr, data[0..@sizeOf(Ehdr)]);
 
     if (!std.mem.eql(u8, header.e_ident[0..4], std.elf.MAGIC)) return Error.InvalidElf;
     if (header.e_ident[std.elf.EI_CLASS] != std.elf.ELFCLASS32) return Error.UnsupportedElf;
@@ -49,31 +48,43 @@ fn parse_header(data: []const u8) !Ehdr {
 
     // program header table must exist and be within the file
     if (header.e_phoff == 0 or header.e_phnum == 0) return Error.InvalidElf;
-    if (!in_bounds(header.e_phoff, @as(usize, header.e_phnum) * @as(usize, header.e_phentsize), data.len))
+    // entries smaller than a Phdr would make PhdrIterator read past the table
+    if (header.e_phentsize < @sizeOf(Phdr)) return Error.InvalidElf;
+    if (!in_bounds(header.e_phoff, @as(usize, header.e_phnum) * header.e_phentsize, data.len))
         return Error.InvalidElf;
 
     return header;
 }
 
-fn phdr_at(data: []const u8, header: Ehdr, index: usize) Phdr {
-    const offset = @as(usize, header.e_phoff) + index * @as(usize, header.e_phentsize);
-    return @as(*const Phdr, @ptrCast(@alignCast(data.ptr + offset))).*;
-}
+/// Walks the program header table. Only valid on a header returned by parse_header,
+/// which has checked the whole table lies within 'data'.
+const PhdrIterator = struct {
+    data: []const u8,
+    header: Ehdr,
+    index: usize = 0,
 
-fn check_segment(data: []const u8, phdr: Phdr) !void {
+    fn next(self: *PhdrIterator) ?Phdr {
+        if (self.index >= self.header.e_phnum) return null;
+        defer self.index += 1;
+        const offset = self.header.e_phoff + self.index * @as(usize, self.header.e_phentsize);
+        return std.mem.bytesToValue(Phdr, self.data[offset..][0..@sizeOf(Phdr)]);
+    }
+};
+
+fn check_segment(data: []const u8, phdr: Phdr) Error!void {
     if (phdr.p_filesz > phdr.p_memsz) return Error.InvalidElf; // file size can't be larger than memory size
-    if (!in_bounds(@as(usize, phdr.p_offset), @as(usize, phdr.p_filesz), data.len)) return Error.InvalidElf;
+    if (!in_bounds(phdr.p_offset, phdr.p_filesz, data.len)) return Error.InvalidElf;
 
-    // check that the segment is within the user space
-    const vm_end = std.math.add(usize, @as(usize, phdr.p_vaddr), @as(usize, phdr.p_memsz)) catch
-        return Error.InvalidElf;
-    if (vm_end > paging.high_half) return Error.InvalidElf; // overflow
+    const vm_end = std.math.add(usize, phdr.p_vaddr, phdr.p_memsz) catch return Error.InvalidElf;
+    // the segment is wellformed but reaches into the kernel half, so we cannot map it
+    if (vm_end > paging.high_half) return Error.InvalidElf;
 }
 
-pub fn validate(data: []const u8) !void {
+pub fn validate(data: []const u8) Error!void {
     const header = try parse_header(data);
-    for (0..header.e_phnum) |i| {
-        const phdr = phdr_at(data, header, i);
+
+    var it = PhdrIterator{ .data = data, .header = header };
+    while (it.next()) |phdr| {
         switch (phdr.p_type) {
             std.elf.PT_LOAD => try check_segment(data, phdr),
             std.elf.PT_INTERP => return Error.UnsupportedElf, // dynamic linking not supported yet
@@ -82,7 +93,7 @@ pub fn validate(data: []const u8) !void {
     }
 }
 
-pub fn load_segment(vm: *VirtualSpace, data: []const u8, phdr: Phdr) !void {
+fn load_segment(vm: *VirtualSpace, data: []const u8, phdr: Phdr) Error!void {
     try check_segment(data, phdr);
 
     const vm_start = std.mem.alignBackward(usize, phdr.p_vaddr, paging.page_size);
@@ -97,7 +108,7 @@ pub fn load_segment(vm: *VirtualSpace, data: []const u8, phdr: Phdr) !void {
         return Error.LoadFailed;
 
     const dest: [*]u8 = @ptrFromInt(phdr.p_vaddr);
-    @memcpy(dest, data[phdr.p_offset..][0..phdr.p_filesz]);
+    @memcpy(dest[0..phdr.p_filesz], data[phdr.p_offset..][0..phdr.p_filesz]);
 
     // since we're not using physical address extension, any readable page is also executable.
     // we only need to handle the write permission here
@@ -108,20 +119,20 @@ pub fn load_segment(vm: *VirtualSpace, data: []const u8, phdr: Phdr) !void {
     }
 }
 
-pub fn load(vm: *VirtualSpace, data: []const u8) !Image {
+pub fn load(vm: *VirtualSpace, data: []const u8) Error!Image {
     const header = try parse_header(data);
+    const table_size = @as(usize, header.e_phentsize) * header.e_phnum;
 
     var phdr_vaddr: usize = 0;
-    for (0..header.e_phnum) |i| {
-        const phdr = phdr_at(data, header, i);
+    var it = PhdrIterator{ .data = data, .header = header };
+    while (it.next()) |phdr| {
         switch (phdr.p_type) {
             std.elf.PT_LOAD => {
                 try load_segment(vm, data, phdr);
-                const table_size = @as(usize, header.e_phentsize) * header.e_phnum;
                 if (phdr_vaddr == 0 and
                     header.e_phoff >= phdr.p_offset and
                     in_bounds(header.e_phoff - phdr.p_offset, table_size, phdr.p_filesz))
-                    phdr_vaddr = @as(usize, phdr.p_vaddr) + (header.e_phoff - @as(usize, phdr.p_offset));
+                    phdr_vaddr = phdr.p_vaddr + (header.e_phoff - phdr.p_offset);
             },
             std.elf.PT_INTERP => return Error.UnsupportedElf, // dynamic linking not supported yet
             else => {}, // ignore other segment types

--- a/src/task/elf.zig
+++ b/src/task/elf.zig
@@ -1,0 +1,69 @@
+const std = @import("std");
+const paging = @import("../memory/paging.zig");
+
+pub const Error = error{
+    // malformed or invalid ELF file (inconsistent headers, program table etc)
+    InvalidElf,
+    // wellformed but can't execute: wrong class/endian/machine/type or dynamic (PT_INTERP), loader only static for now
+    UnsupportedElf,
+    // ran out of regions / memory while loading the image
+    LoadFailed,
+};
+
+const Ehdr = std.elf.Ehdr; // std.elf.Ehdr -> std.elf.Elf32_Ehdr on i386
+const Phdr = std.elf.Phdr; // std.elf.Phdr -> std.elf.Elf32_Phdr on i386
+
+/// Returns true if the range [offset, offset + len[ is within [0, total[
+inline fn in_bounds(offset: usize, len: usize, total: usize) bool {
+    // check for overflow
+    const end = std.math.add(usize, offset, len) catch return false;
+    return end <= total;
+}
+
+fn parse_header(data: []const u8) !Ehdr {
+    if (data.len < @sizeOf(Ehdr)) return Error.InvalidElf;
+    const header: Ehdr = @as(*const Ehdr, @ptrCast(@alignCast(data.ptr))).*;
+
+    if (!std.mem.eql(u8, header.e_ident[0..4], std.elf.MAGIC)) return Error.InvalidElf;
+    if (header.e_ident[std.elf.EI_CLASS] != std.elf.ELFCLASS32) return Error.UnsupportedElf;
+    if (header.e_ident[std.elf.EI_DATA] != std.elf.ELFDATA2LSB) return Error.UnsupportedElf;
+    if (header.e_machine != .@"386") return Error.UnsupportedElf;
+
+    // We only support static executables (ET_DYN/PIE are rejected for now)
+    // TODO: remove this check when we implement dynamic linking
+    if (header.e_type != .EXEC) return Error.UnsupportedElf;
+
+    // program header table must exist and be within the file
+    if (header.e_phoff == 0 or header.e_phnum == 0) return Error.InvalidElf;
+    if (!in_bounds(header.e_phoff, @as(usize, header.e_phnum) * @as(usize, header.e_phentsize), data.len))
+        return Error.InvalidElf;
+
+    return header;
+}
+
+fn phdr_at(data: []const u8, header: Ehdr, index: usize) Phdr {
+    const offset = @as(usize, header.e_phoff) + index * @as(usize, header.e_phentsize);
+    return @as(*const Phdr, @ptrCast(@alignCast(data.ptr + offset))).*;
+}
+
+fn check_segment(data: []const u8, phdr: Phdr) !void {
+    if (phdr.p_filesz > phdr.p_memsz) return Error.InvalidElf; // file size can't be larger than memory size
+    if (!in_bounds(@as(usize, phdr.p_offset), @as(usize, phdr.p_filesz), data.len)) return Error.InvalidElf;
+
+    // check that the segment is within the user space
+    const vm_end = std.math.add(usize, @as(usize, phdr.p_vaddr), @as(usize, phdr.p_memsz)) catch
+        return Error.InvalidElf;
+    if (vm_end > paging.high_half) return Error.InvalidElf; // overflow
+}
+
+pub fn validate(data: []const u8) !void {
+    const header = try parse_header(data);
+    for (0..header.e_phnum) |i| {
+        const phdr = phdr_at(data, header, i);
+        switch (phdr.p_type) {
+            std.elf.PT_LOAD => try check_segment(data, phdr),
+            std.elf.PT_INTERP => return Error.UnsupportedElf, // dynamic linking not supported yet
+            else => {}, // ignore other segment types
+        }
+    }
+}

--- a/src/task/elf.zig
+++ b/src/task/elf.zig
@@ -1,6 +1,16 @@
 const std = @import("std");
 const paging = @import("../memory/paging.zig");
 
+/// Everything a sysv i386 '_start' (and later a dynamic linker) needs to bootstrap a process.
+/// 'phdr_vaddr' is the runtime address of the program header table when a PT_LOAD segment maps it,
+/// else 0
+pub const Image = struct {
+    entry: usize,
+    phdr_vaddr: usize,
+    phentsize: u16,
+    phnum: u16,
+};
+
 pub const Error = error{
     // malformed or invalid ELF file (inconsistent headers, program table etc)
     InvalidElf,
@@ -12,6 +22,10 @@ pub const Error = error{
 
 const Ehdr = std.elf.Ehdr; // std.elf.Ehdr -> std.elf.Elf32_Ehdr on i386
 const Phdr = std.elf.Phdr; // std.elf.Phdr -> std.elf.Elf32_Phdr on i386
+
+const regions = @import("../memory/regions.zig");
+const RegionSet = @import("../memory/region_set.zig").RegionSet;
+const VirtualSpace = @import("../memory/virtual_space.zig").VirtualSpace;
 
 /// Returns true if the range [offset, offset + len[ is within [0, total[
 inline fn in_bounds(offset: usize, len: usize, total: usize) bool {
@@ -66,4 +80,58 @@ pub fn validate(data: []const u8) !void {
             else => {}, // ignore other segment types
         }
     }
+}
+
+pub fn load_segment(vm: *VirtualSpace, data: []const u8, phdr: Phdr) !void {
+    try check_segment(data, phdr);
+
+    const vm_start = std.mem.alignBackward(usize, phdr.p_vaddr, paging.page_size);
+    const vm_end = std.mem.alignForward(usize, phdr.p_vaddr + phdr.p_memsz, paging.page_size);
+
+    const region = RegionSet.create_region() catch return Error.LoadFailed;
+    errdefer RegionSet.destroy_region(region) catch unreachable;
+    region.flags = .{ .write = true, .read = true, .may_write = true, .may_read = true };
+    regions.VirtuallyContiguousRegion.init(region, .{ .private = true });
+
+    vm.add_region_at(region, vm_start / paging.page_size, (vm_end - vm_start) / paging.page_size, false) catch
+        return Error.LoadFailed;
+
+    const dest: [*]u8 = @ptrFromInt(phdr.p_vaddr);
+    @memcpy(dest, data[phdr.p_offset..][0..phdr.p_filesz]);
+
+    // since we're not using physical address extension, any readable page is also executable.
+    // we only need to handle the write permission here
+    if (phdr.p_flags & std.elf.PF_W == 0) {
+        region.flags.write = false;
+        region.flags.may_write = false;
+        region.flush();
+    }
+}
+
+pub fn load(vm: *VirtualSpace, data: []const u8) !Image {
+    const header = try parse_header(data);
+
+    var phdr_vaddr: usize = 0;
+    for (0..header.e_phnum) |i| {
+        const phdr = phdr_at(data, header, i);
+        switch (phdr.p_type) {
+            std.elf.PT_LOAD => {
+                try load_segment(vm, data, phdr);
+                const table_size = @as(usize, header.e_phentsize) * header.e_phnum;
+                if (phdr_vaddr == 0 and
+                    header.e_phoff >= phdr.p_offset and
+                    in_bounds(header.e_phoff - phdr.p_offset, table_size, phdr.p_filesz))
+                    phdr_vaddr = @as(usize, phdr.p_vaddr) + (header.e_phoff - @as(usize, phdr.p_offset));
+            },
+            std.elf.PT_INTERP => return Error.UnsupportedElf, // dynamic linking not supported yet
+            else => {}, // ignore other segment types
+        }
+    }
+
+    return Image{
+        .entry = header.e_entry,
+        .phdr_vaddr = phdr_vaddr,
+        .phentsize = header.e_phentsize,
+        .phnum = header.e_phnum,
+    };
 }

--- a/src/task/sysv.zig
+++ b/src/task/sysv.zig
@@ -37,18 +37,21 @@ pub const SysvLayout = struct {
 
     fn build_auxv(image: elf.Image, buf: *[max_auxv]std.elf.Auxv) []std.elf.Auxv {
         var len: usize = 0;
+
         // refering to the sysv i386 ABI:
-        // If the AT_PHDR entry is present, entries of types AT_PHENT, AT_PHNUM, and AT_ENTRY must also be present
+        // - If the AT_PHDR entry is present, entries of types AT_PHENT, AT_PHNUM, and AT_ENTRY must also be present.
+        // Note: That is an implication, not an equivalence: AT_ENTRY alone would be legal, and still informative for
+        // an image with no program header table.
         if (image.phdr_vaddr != 0) {
-            buf[0] = std.elf.Auxv{ .a_type = std.elf.AT_PHDR, .a_un = .{ .a_val = image.phdr_vaddr } };
-            buf[1] = std.elf.Auxv{ .a_type = std.elf.AT_PHENT, .a_un = .{ .a_val = image.phentsize } };
-            buf[2] = std.elf.Auxv{ .a_type = std.elf.AT_PHNUM, .a_un = .{ .a_val = image.phnum } };
-            buf[3] = std.elf.Auxv{ .a_type = std.elf.AT_ENTRY, .a_un = .{ .a_val = image.entry } };
-            len += 4;
+            buf[0] = .{ .a_type = std.elf.AT_PHDR, .a_un = .{ .a_val = image.phdr_vaddr } };
+            buf[1] = .{ .a_type = std.elf.AT_PHENT, .a_un = .{ .a_val = image.phentsize } };
+            buf[2] = .{ .a_type = std.elf.AT_PHNUM, .a_un = .{ .a_val = image.phnum } };
+            len += 3;
         }
-        buf[len] = std.elf.Auxv{ .a_type = std.elf.AT_PAGESZ, .a_un = .{ .a_val = paging.page_size } };
-        buf[len + 1] = std.elf.Auxv{ .a_type = std.elf.AT_NULL, .a_un = .{ .a_val = 0 } };
-        return buf[0 .. len + 2];
+        buf[len] = .{ .a_type = std.elf.AT_ENTRY, .a_un = .{ .a_val = image.entry } };
+        buf[len + 1] = .{ .a_type = std.elf.AT_PAGESZ, .a_un = .{ .a_val = paging.page_size } };
+        buf[len + 2] = .{ .a_type = std.elf.AT_NULL, .a_un = .{ .a_val = 0 } };
+        return buf[0 .. len + 3];
     }
 
     /// Upper bound on the bytes the entry block occupies below `stack_top`. The trailing

--- a/src/task/sysv.zig
+++ b/src/task/sysv.zig
@@ -61,15 +61,18 @@ pub const SysvLayout = struct {
     }
 };
 
-/// Two cursors moving towards each other inside the entry block: `words` fills the
-/// argc/argv/envp/auxv array upwards from the bottom, `str_top` copies the strings
-/// downwards from the top. SysvLayout.size() guarantees they never meet.
+/// The pointer table fills upwards from the bottom of the entry block, and the
+/// strings fill upwards from the base of the string area packed against
+/// stack_top. Both grow in push order, so argv[0] lands at the lowest string
+/// address following the classic Unix layout some programs expect.
+/// SysvLayout.size() guarantees the two areas never overlap.
 const Builder = struct {
     const Self = @This();
 
     words: [*]usize,
     count: usize = 0,
-    str_top: usize,
+    /// Next free byte in the string area.
+    str_next: usize,
 
     fn push_word(self: *Self, value: usize) void {
         self.words[self.count] = value;
@@ -79,13 +82,12 @@ const Builder = struct {
     /// Copy str (NUL terminator included) into the string area, then push its address.
     fn push_str(self: *Self, str: [:0]const u8) void {
         const len = str.len + 1;
-        self.str_top -= len;
-        const dst: [*]u8 = @ptrFromInt(self.str_top);
+        const dst: [*]u8 = @ptrFromInt(self.str_next);
         @memcpy(dst[0..len], str.ptr[0..len]);
-        self.push_word(self.str_top);
+        self.push_word(self.str_next);
+        self.str_next += len;
     }
 
-    /// Push a NULL-terminated vector of string pointers.
     fn push_vector(self: *Self, strs: []const [:0]const u8) void {
         for (strs) |str| self.push_str(str);
         self.push_word(0);
@@ -102,16 +104,18 @@ pub fn build_sysv_stack(
 ) usize {
     const layout = SysvLayout.init(argv, envp, image);
     const stack_ptr = std.mem.alignBackward(usize, stack_top - layout.size(), 16);
+    const strs_base = stack_top - layout.strs_len;
 
-    var builder: Builder = .{ .words = @ptrFromInt(stack_ptr), .str_top = stack_top };
+    var builder: Builder = .{ .words = @ptrFromInt(stack_ptr), .str_next = strs_base };
     builder.push_word(argv.len); // argc
     builder.push_vector(argv);
     builder.push_vector(envp);
     std.debug.assert(builder.count == layout.n_words);
+    std.debug.assert(builder.str_next == stack_top);
 
     const auxv = layout.auxv_bytes();
     const auxv_at = stack_ptr + builder.count * @sizeOf(usize);
-    std.debug.assert(auxv_at + auxv.len <= builder.str_top);
+    std.debug.assert(auxv_at + auxv.len <= strs_base);
 
     const dst: [*]u8 = @ptrFromInt(auxv_at);
     @memcpy(dst[0..auxv.len], auxv);

--- a/src/task/sysv.zig
+++ b/src/task/sysv.zig
@@ -1,0 +1,117 @@
+const std = @import("std");
+const elf = @import("elf.zig");
+const paging = @import("../memory/paging.zig");
+
+/// Most auxv entries we ever emit: AT_PHDR, AT_PHENT, AT_PHNUM, AT_ENTRY, AT_PAGESZ
+/// and the mandatory AT_NULL terminator.
+const max_auxv = 6;
+
+pub const arg_max = 128 * 1024;
+
+pub const SysvLayout = struct {
+    const Self = @This();
+
+    /// total size in bytes of argv/envp strings, NUL terminators included
+    strs_len: usize,
+    /// argc, the argv pointers, their NULL, the envp pointers and their NULL
+    n_words: usize,
+    auxv_buf: [max_auxv]std.elf.Auxv,
+    auxv_len: usize,
+
+    pub fn init(argv: []const [:0]const u8, envp: []const [:0]const u8, image: elf.Image) Self {
+        var self: Self = .{
+            .strs_len = 0,
+            .n_words = 1 + argv.len + 1 + envp.len + 1,
+            .auxv_buf = undefined,
+            .auxv_len = 0,
+        };
+        for (argv) |arg| self.strs_len += arg.len + 1;
+        for (envp) |env| self.strs_len += env.len + 1;
+        self.auxv_len = build_auxv(image, &self.auxv_buf).len;
+        return self;
+    }
+
+    fn auxv_bytes(self: *const Self) []const u8 {
+        return std.mem.sliceAsBytes(self.auxv_buf[0..self.auxv_len]);
+    }
+
+    fn build_auxv(image: elf.Image, buf: *[max_auxv]std.elf.Auxv) []std.elf.Auxv {
+        var len: usize = 0;
+        // refering to the sysv i386 ABI:
+        // If the AT_PHDR entry is present, entries of types AT_PHENT, AT_PHNUM, and AT_ENTRY must also be present
+        if (image.phdr_vaddr != 0) {
+            buf[0] = std.elf.Auxv{ .a_type = std.elf.AT_PHDR, .a_un = .{ .a_val = image.phdr_vaddr } };
+            buf[1] = std.elf.Auxv{ .a_type = std.elf.AT_PHENT, .a_un = .{ .a_val = image.phentsize } };
+            buf[2] = std.elf.Auxv{ .a_type = std.elf.AT_PHNUM, .a_un = .{ .a_val = image.phnum } };
+            buf[3] = std.elf.Auxv{ .a_type = std.elf.AT_ENTRY, .a_un = .{ .a_val = image.entry } };
+            len += 4;
+        }
+        buf[len] = std.elf.Auxv{ .a_type = std.elf.AT_PAGESZ, .a_un = .{ .a_val = paging.page_size } };
+        buf[len + 1] = std.elf.Auxv{ .a_type = std.elf.AT_NULL, .a_un = .{ .a_val = 0 } };
+        return buf[0 .. len + 2];
+    }
+
+    /// Upper bound on the bytes the entry block occupies below `stack_top`. The trailing
+    /// 16 bytes cover the padding that aligning the final stack pointer may consume.
+    pub fn size(self: *const Self) usize {
+        return self.strs_len + self.n_words * @sizeOf(usize) + self.auxv_bytes().len + 16;
+    }
+};
+
+/// Two cursors moving towards each other inside the entry block: `words` fills the
+/// argc/argv/envp/auxv array upwards from the bottom, `str_top` copies the strings
+/// downwards from the top. SysvLayout.size() guarantees they never meet.
+const Builder = struct {
+    const Self = @This();
+
+    words: [*]usize,
+    count: usize = 0,
+    str_top: usize,
+
+    fn push_word(self: *Self, value: usize) void {
+        self.words[self.count] = value;
+        self.count += 1;
+    }
+
+    /// Copy str (NUL terminator included) into the string area, then push its address.
+    fn push_str(self: *Self, str: [:0]const u8) void {
+        const len = str.len + 1;
+        self.str_top -= len;
+        const dst: [*]u8 = @ptrFromInt(self.str_top);
+        @memcpy(dst[0..len], str.ptr[0..len]);
+        self.push_word(self.str_top);
+    }
+
+    /// Push a NULL-terminated vector of string pointers.
+    fn push_vector(self: *Self, strs: []const [:0]const u8) void {
+        for (strs) |str| self.push_str(str);
+        self.push_word(0);
+    }
+};
+
+/// Build the sysv i386 entry block at the top of a mapped user stack and return the
+/// initial esp, pointing at argc and 16-byte aligned as the ABI requires.
+pub fn build_sysv_stack(
+    stack_top: usize,
+    argv: []const [:0]const u8,
+    envp: []const [:0]const u8,
+    image: elf.Image,
+) usize {
+    const layout = SysvLayout.init(argv, envp, image);
+    const stack_ptr = std.mem.alignBackward(usize, stack_top - layout.size(), 16);
+
+    var builder: Builder = .{ .words = @ptrFromInt(stack_ptr), .str_top = stack_top };
+    builder.push_word(argv.len); // argc
+    builder.push_vector(argv);
+    builder.push_vector(envp);
+    std.debug.assert(builder.count == layout.n_words);
+
+    const auxv = layout.auxv_bytes();
+    const auxv_at = stack_ptr + builder.count * @sizeOf(usize);
+    std.debug.assert(auxv_at + auxv.len <= builder.str_top);
+
+    const dst: [*]u8 = @ptrFromInt(auxv_at);
+    @memcpy(dst[0..auxv.len], auxv);
+
+    return stack_ptr;
+}


### PR DESCRIPTION
task/elf.zig validates an image and copies every PT_LOAD into a virtual space. task/sysv.zig builds the entry block a SysV process expects on its stack: argc, argv, envp, auxv, with the strings laid out in ascending order.

Nothing calls them yet, that is next PR (ELF exec). test_elf is a builtin to validate an image and report its mapped regions.