### PR TITLE
ELF exec

### DIFF
--- a/src/shell/default/builtins.zig
+++ b/src/shell/default/builtins.zig
@@ -371,9 +371,10 @@ pub fn demo(shell: anytype, args: [][]u8) CmdError!void {
         "io",
         "ctty",
         "jobctl",
+        "execve",
     };
 
-    if (args.len != 2) {
+    if (args.len < 2) {
         shell.print("Available routines:\n", .{});
         for (array) |f| {
             shell.print("- {s}\n", .{f});
@@ -381,8 +382,16 @@ pub fn demo(shell: anytype, args: [][]u8) CmdError!void {
         return CmdError.InvalidNumberOfArguments;
     }
 
+    const poc = @import("../../userspace.poc.zig");
+
     inline for (array) |name| {
         if (std.mem.eql(u8, name, args[1])) {
+            // Lives on our frame, which outlives the call: spawn() runs the demo before
+            // we resume, and it copies argv onto the user stack straight away.
+            var req = poc.DemoRequest{
+                .entry = @intFromPtr(@extern(?*fn () void, .{ .name = "userland_" ++ name }).?),
+                .argv = args[1..],
+            };
             const new_task = @import("../../task/task_set.zig").create_task() catch
                 @panic("Failed to create new_task");
             // A job of its own, so that the terminal can signal it without
@@ -394,10 +403,8 @@ pub fn demo(shell: anytype, args: [][]u8) CmdError!void {
             const previous = utils.foreground(new_task);
             defer utils.restore_foreground(previous);
 
-            new_task.spawn(
-                &@import("../../userspace.poc.zig").enter_demo,
-                @intFromPtr(@extern(?*fn () void, .{ .name = "userland_" ++ name }).?),
-            ) catch @panic("Failed to spawn new_task");
+            new_task.spawn(&poc.enter_demo, @intFromPtr(&req)) catch
+                @panic("Failed to spawn new_task");
             utils.waitpid(shell, new_task.pid);
             return;
         }

--- a/src/shell/default/builtins.zig
+++ b/src/shell/default/builtins.zig
@@ -395,7 +395,7 @@ pub fn demo(shell: anytype, args: [][]u8) CmdError!void {
             defer utils.restore_foreground(previous);
 
             new_task.spawn(
-                &@import("../../task/userspace.zig").call_userspace,
+                &@import("../../userspace.poc.zig").enter_demo,
                 @intFromPtr(@extern(?*fn () void, .{ .name = "userland_" ++ name }).?),
             ) catch @panic("Failed to spawn new_task");
             utils.waitpid(shell, new_task.pid);

--- a/src/syscall/execve.zig
+++ b/src/syscall/execve.zig
@@ -1,0 +1,48 @@
+const std = @import("std");
+pub const Id = 25;
+const Errno = @import("../errno.zig").Errno;
+const vfs = @import("../fs/vfs.zig");
+const TNode = @import("../fs/tnode.zig");
+const INode = @import("../fs/inode.zig");
+const scheduler = @import("../task/scheduler.zig");
+const TaskDescriptor = @import("../task/task.zig").TaskDescriptor;
+const sysv = @import("../task/sysv.zig");
+
+const allocator = @import("../memory.zig").smallAlloc.allocator();
+
+// Every entry costs at least one pointer word in the sysv entry block, so arg_max
+// already bounds how many we can ever accept. exec() checks the strings themselves.
+const max_entries = sysv.arg_max / @sizeOf(usize);
+
+/// Walk a NULL terminated userspace pointer array into a kernel side slice of slices.
+/// The strings are left in place, exec() copies them before the address space swap.
+fn collect(arr: [*:null]const ?[*:0]const u8) Errno![]const []const u8 {
+    var len: usize = 0;
+    while (arr[len] != null) : (len += 1) {
+        if (len == max_entries) return Errno.E2BIG;
+    }
+
+    const out = allocator.alloc([]const u8, len) catch return Errno.ENOMEM;
+    for (out, 0..) |*slot, i| slot.* = std.mem.span(arr[i].?);
+    return out;
+}
+
+pub fn do(path: [*:0]const u8, argv: [*:null]const ?[*:0]const u8, envp: [*:null]const ?[*:0]const u8) Errno!void {
+    const tnode = try vfs.resolve(std.mem.span(path));
+    errdefer tnode.release();
+
+    const argv_slices = try collect(argv);
+    errdefer allocator.free(argv_slices);
+    const envp_slices = try collect(envp);
+    errdefer allocator.free(envp_slices);
+
+    const req = try TaskDescriptor.prepare_exec(tnode.inode, argv_slices, envp_slices);
+
+    // Nothing can fail past this point, and commit_exec does not come back: it resets the
+    // kernel stack this frame lives on. Release what we own now, no defer would ever run.
+    allocator.free(envp_slices);
+    allocator.free(argv_slices);
+    tnode.release();
+
+    scheduler.get_current_task().commit_exec(req);
+}

--- a/src/task/task.zig
+++ b/src/task/task.zig
@@ -19,6 +19,13 @@ const Errno = @import("../errno.zig").Errno;
 const vfs = @import("../fs/vfs.zig");
 const TNode = @import("../fs/tnode.zig");
 const FileSet = @import("file_set.zig");
+const INode = @import("../fs/inode.zig");
+const elf = @import("elf.zig");
+const sysv = @import("sysv.zig");
+const userspace = @import("userspace.zig");
+
+const heapAlloc = memory.bigAlloc.allocator();
+const smallAlloc = memory.smallAlloc.allocator();
 
 const callback_allocator = @import("../memory.zig").smallAlloc.allocator();
 const Callback = *const fn (*TaskDescriptor) void;
@@ -197,17 +204,147 @@ pub const TaskDescriptor = struct {
         } else @panic("todo");
     }
 
-    pub fn init_vm(self: *Self) !void {
-        if (self.vm != null) {
-            @panic("task already has a vm");
+    fn deinit_vm(self: *Self) void {
+        if (self.vm) |vm| {
+            destroy_vm(vm);
+            self.vm = null;
         }
+    }
+
+    fn destroy_vm(vm: *VirtualSpace) void {
+        vm.deinit();
+        VirtualSpace.cache.allocator().destroy(vm);
+    }
+
+    fn create_vm() !*VirtualSpace {
         const vm = try VirtualSpace.cache.allocator().create(VirtualSpace);
         try vm.init();
         try vm.add_space(0, paging.high_half / paging.page_size);
         try vm.add_space((paging.page_tables) / paging.page_size, 768);
         vm.transfer();
         try vm.fill_page_tables(paging.page_tables / paging.page_size, 768, false);
-        self.vm = vm;
+        return vm;
+    }
+
+    pub fn init_vm(self: *Self) !void {
+        if (self.vm != null) {
+            @panic("task already has a vm");
+        }
+        self.vm = try create_vm();
+    }
+
+    pub fn dupe_strings_z(strings: []const []const u8) Errno![]const [:0]const u8 {
+        const out = smallAlloc.alloc([:0]const u8, strings.len) catch return Errno.ENOMEM;
+        errdefer smallAlloc.free(out);
+        var filled: usize = 0;
+        errdefer for (out[0..filled]) |s| smallAlloc.free(s);
+        for (strings, 0..) |s, i| {
+            out[i] = smallAlloc.dupeZ(u8, s) catch return Errno.ENOMEM;
+            filled += 1;
+        }
+        return out;
+    }
+
+    pub fn free_strings_z(strings: []const [:0]const u8) void {
+        for (strings) |s| smallAlloc.free(s);
+        smallAlloc.free(strings);
+    }
+
+    pub const ExecRequest = struct {
+        data: []const u8,
+        argv: []const [:0]const u8,
+        envp: []const [:0]const u8,
+    };
+
+    /// Everything about an exec that can fail: read the image, validate it, and copy
+    /// argv/envp into kernel memory. Touches no task, so on error nothing is committed
+    /// and the caller's own resources are still safe to release.
+    /// The returned request is owned by the matching commit_exec.
+    pub fn prepare_exec(
+        inode: *INode,
+        argv: []const []const u8,
+        envp: []const []const u8,
+    ) Errno!*ExecRequest {
+        const file = try inode.open();
+        defer file.close() catch {};
+
+        var magic: [2]u8 = undefined;
+        if (try file.pread(0, magic[0..]) != magic.len) {
+            return Errno.EINVAL;
+        }
+        if (std.mem.eql(u8, magic[0..], "#!")) {
+            @panic("Must implement shebang");
+        }
+
+        const data = heapAlloc.alloc(u8, std.math.cast(usize, inode.size) orelse return Errno.E2BIG) catch
+            return Errno.ENOMEM;
+        errdefer heapAlloc.free(data);
+        if (try file.pread(0, data) != data.len)
+            return Errno.EIO;
+        elf.validate(data) catch |e| return switch (e) {
+            error.InvalidElf, error.UnsupportedElf => Errno.ENOEXEC,
+            error.LoadFailed => unreachable, // validate do not map anything
+        };
+
+        var count: usize = 0;
+        for (argv) |arg| count += arg.len + 1;
+        for (envp) |env| count += env.len + 1;
+        if (count > sysv.arg_max) return Errno.E2BIG;
+
+        const argv_z = try dupe_strings_z(argv);
+        errdefer free_strings_z(argv_z);
+        const envp_z = try dupe_strings_z(envp);
+        errdefer free_strings_z(envp_z);
+
+        const req = smallAlloc.create(ExecRequest) catch return Errno.ENOMEM;
+        req.* = .{ .data = data, .argv = argv_z, .envp = envp_z };
+        return req;
+    }
+
+    /// The half that cannot fail, and does not come back: it resets the kernel stack
+    /// the caller is running on.
+    pub fn commit_exec(self: *Self, req: *ExecRequest) void {
+        self.spawn(&exec_entry, @intFromPtr(req)) catch @panic("Failed to spawn exec task");
+    }
+
+    fn load_image(
+        file_data: []const u8,
+        argv_z: []const [:0]const u8,
+        envp_z: []const [:0]const u8,
+    ) !userspace.PreparedEntry {
+        // load() copies every PT_LOAD into the new vm, and build_sysv_stack copies
+        // the strings onto the user stack: none of these outlive this function.
+        defer heapAlloc.free(file_data);
+        defer free_strings_z(argv_z);
+        defer free_strings_z(envp_z);
+
+        const self = scheduler.get_current_task();
+
+        const new_vm = try create_vm();
+        errdefer destroy_vm(new_vm);
+
+        const image = try elf.load(new_vm, file_data);
+
+        userspace.map_userspace(new_vm);
+        const entry = userspace.prepare_entry(new_vm, image, argv_z, envp_z);
+
+        self.deinit_vm();
+        self.vm = new_vm;
+        return entry;
+    }
+
+    fn exec_entry(data: usize) u8 {
+        const request: *ExecRequest = @ptrFromInt(data);
+        const file_data = request.data;
+        const argv_z = request.argv;
+        const envp_z = request.envp;
+        smallAlloc.destroy(request);
+
+        // Everything fallible lives in a function that actually returns, so its
+        // defer/errdefer run, only the ring-3 jump below is noreturn, and by then
+        // there is nothing left to release.
+        const entry = load_image(file_data, argv_z, envp_z) catch exit(1);
+        userspace.iret_to(entry);
     }
 
     pub fn clone_vm(self: *Self, other: *Self) !void {

--- a/src/task/userspace.zig
+++ b/src/task/userspace.zig
@@ -1,45 +1,14 @@
 const std = @import("std");
 const gdt = @import("../gdt.zig");
 const cpu = @import("../cpu.zig");
+const elf = @import("elf.zig");
+const sysv = @import("sysv.zig");
 const memory = @import("../memory.zig");
 const VirtualSpace = @import("../memory/virtual_space.zig").VirtualSpace;
 const paging = @import("../memory/paging.zig");
 const interrupts = @import("../interrupts.zig");
-const scheduler = @import("scheduler.zig");
 const RegionSet = @import("../memory/region_set.zig").RegionSet;
 const regions = @import("../memory/regions.zig");
-
-fn map_userspace(vm: *VirtualSpace) void {
-    const up_start = std.mem.alignBackward(u32, @intFromPtr(@extern(*u8, .{ .name = "userspace_start" })), 4096);
-    const up_end = std.mem.alignForward(u32, @intFromPtr(@extern(*u8, .{ .name = "userspace_end" })), 4096);
-
-    const region = RegionSet.create_region() catch @panic("cannot map userspace");
-    errdefer RegionSet.destroy_region(region) catch unreachable;
-
-    region.flags = .{
-        .read = true,
-        .write = true,
-        .may_read = true,
-        .may_write = true,
-    };
-
-    regions.PhysicalMapping.init(region, 0);
-
-    vm.add_region_at(
-        region,
-        up_start / paging.page_size,
-        (up_end - up_start) / paging.page_size,
-        true,
-    ) catch @panic("cannot map userspace");
-}
-comptime {
-    _ = @import("../userspace.poc.zig");
-}
-
-pub fn call_userspace(f: usize) u8 {
-    clone(f);
-    return 0;
-}
 
 fn create_stack(vm: *VirtualSpace, size: usize) paging.VirtualPagePtr {
     const region = RegionSet.create_region() catch @panic("cannot map userspace");
@@ -61,17 +30,34 @@ fn create_stack(vm: *VirtualSpace, size: usize) paging.VirtualPagePtr {
     return @ptrFromInt(region.begin * paging.page_size);
 }
 
-pub fn clone(entrypoint: usize) noreturn {
-    const task = scheduler.get_current_task();
-    task.init_vm() catch @panic("todo Failed to initialize userspace");
+const stack_pages: usize = 8; // todo: get this from config (static or dynamic)
 
-    const vm = task.vm.?;
+pub const PreparedEntry = struct { vm: *VirtualSpace, ip: usize, sp: usize };
 
-    map_userspace(vm);
+pub fn prepare_entry(
+    vm: *VirtualSpace,
+    image: elf.Image,
+    argv: []const [:0]const u8,
+    envp: []const [:0]const u8,
+) PreparedEntry {
+    const sysv_block_size = sysv.SysvLayout.init(argv, envp, image).size();
+    std.debug.assert(sysv_block_size <= sysv.arg_max);
 
-    const stack_size: usize = 8; // todo: get this from config (static or dynamic)
-    const stack = create_stack(vm, stack_size);
+    const block_pages = std.math.divCeil(usize, sysv_block_size, paging.page_size) catch unreachable;
+    const total_pages = stack_pages + block_pages;
 
+    const stack = create_stack(vm, total_pages);
+    const stack_top = @as(usize, @intFromPtr(stack)) + (paging.page_size * total_pages);
+
+    return PreparedEntry{
+        .vm = vm,
+        .ip = image.entry,
+        .sp = sysv.build_sysv_stack(stack_top, argv, envp, image),
+    };
+}
+
+pub fn iret_to(entry: PreparedEntry) noreturn {
+    entry.vm.transfer();
     const frame = interrupts.InterruptFrame{
         .edi = 0,
         .esi = 0,
@@ -82,13 +68,49 @@ pub fn clone(entrypoint: usize) noreturn {
         .eax = 0,
         .code = 0,
         .iret = .{
-            .ip = entrypoint,
+            .ip = entry.ip,
             .cs = .{ .index = 4, .table = .GDT, .privilege = .User },
             .flags = @bitCast(cpu.EFlags{ .interrupt_enable = true }),
-            .sp = @as(u32, @intFromPtr(stack)) + (paging.page_size * stack_size),
+            .sp = entry.sp,
             .ss = .{ .index = 6, .table = .GDT, .privilege = .User },
         },
     };
-
     interrupts.ret_from_interrupt(&frame);
+}
+
+/// Drop to ring 3 on 'image' inside 'vm'. The caller must have mapped everything the
+/// image needs beforehand, nothing is loaded here.
+pub fn enter_userspace(
+    vm: *VirtualSpace,
+    image: elf.Image,
+    argv: []const [:0]const u8,
+    envp: []const [:0]const u8,
+) noreturn {
+    iret_to(prepare_entry(vm, image, argv, envp));
+}
+
+/// Map the .userspace section into 'vm' so ring 3 can run the userland_* entry points.
+/// Only needed because these demos are kernel-linked code and not loadable images.
+pub fn map_userspace(vm: *VirtualSpace) void {
+    const up_start = std.mem.alignBackward(u32, @intFromPtr(@extern(*u8, .{ .name = "userspace_start" })), 4096);
+    const up_end = std.mem.alignForward(u32, @intFromPtr(@extern(*u8, .{ .name = "userspace_end" })), 4096);
+
+    const region = RegionSet.create_region() catch @panic("cannot map userspace");
+    errdefer RegionSet.destroy_region(region) catch unreachable;
+
+    region.flags = .{
+        .read = true,
+        .write = true,
+        .may_read = true,
+        .may_write = true,
+    };
+
+    regions.PhysicalMapping.init(region, 0);
+
+    vm.add_region_at(
+        region,
+        up_start / paging.page_size,
+        (up_end - up_start) / paging.page_size,
+        true,
+    ) catch @panic("cannot map userspace");
 }

--- a/src/userspace.poc.zig
+++ b/src/userspace.poc.zig
@@ -1,5 +1,24 @@
 const paging = @import("memory/paging.zig");
 const signal = @import("task/signal.zig");
+const userspace = @import("task/userspace.zig");
+const scheduler = @import("task/scheduler.zig");
+
+/// Spawn trampoline for the demos. The Image is synthetic: there is no program
+/// header table, so phdr_vaddr is 0 and no AT_PHDR is emitted.
+pub fn enter_demo(entrypoint: usize) u8 {
+    const task = scheduler.get_current_task();
+    task.init_vm() catch @panic("todo Failed to initialize userspace");
+
+    const vm = task.vm.?;
+    userspace.map_userspace(vm);
+
+    userspace.enter_userspace(vm, .{
+        .entry = entrypoint,
+        .phdr_vaddr = 0,
+        .phentsize = 0,
+        .phnum = 0,
+    }, &[_][:0]const u8{"poc"}, &.{});
+}
 
 fn poc_signal(id: u32) linksection(".userspace") callconv(.c) void {
     const str = " Signal handled\n";

--- a/src/userspace.poc.zig
+++ b/src/userspace.poc.zig
@@ -2,22 +2,43 @@ const paging = @import("memory/paging.zig");
 const signal = @import("task/signal.zig");
 const userspace = @import("task/userspace.zig");
 const scheduler = @import("task/scheduler.zig");
+const TaskDescriptor = @import("task/task.zig").TaskDescriptor;
+const VirtualSpace = @import("memory/virtual_space.zig").VirtualSpace;
+const RegionSet = @import("memory/region_set.zig").RegionSet;
+const regions = @import("memory/regions.zig");
 
-/// Spawn trampoline for the demos. The Image is synthetic: there is no program
-/// header table, so phdr_vaddr is 0 and no AT_PHDR is emitted.
-pub fn enter_demo(entrypoint: usize) u8 {
+/// What the demo builtin hands to enter_demo. 'argv' points at the shell's own storage,
+/// which outlives the call: spawn() switches to the new task immediately, so the strings
+/// are copied to the user stack before the shell resumes.
+pub const DemoRequest = struct {
+    entry: usize,
+    argv: []const []const u8,
+};
+
+/// Spawn trampoline for the demos. The Image is synthetic: there is no program header
+/// table, so phdr_vaddr is 0 and no AT_PHDR (and other entry depending on it) are emitted.
+pub fn enter_demo(data: usize) u8 {
+    const req: *const DemoRequest = @ptrFromInt(data);
+
     const task = scheduler.get_current_task();
     task.init_vm() catch @panic("todo Failed to initialize userspace");
 
     const vm = task.vm.?;
     userspace.map_userspace(vm);
 
-    userspace.enter_userspace(vm, .{
-        .entry = entrypoint,
+    const argv = TaskDescriptor.dupe_strings_z(req.argv) catch @panic("todo Failed to copy argv");
+
+    const entry = userspace.prepare_entry(vm, .{
+        .entry = req.entry,
         .phdr_vaddr = 0,
         .phentsize = 0,
         .phnum = 0,
-    }, &[_][:0]const u8{"poc"}, &.{});
+    }, argv, &.{});
+
+    // prepare_entry copied the strings onto the user stack, and iret_to is noreturn,
+    // so release here: a defer would never run.
+    TaskDescriptor.free_strings_z(argv);
+    userspace.iret_to(entry);
 }
 
 fn poc_signal(id: u32) linksection(".userspace") callconv(.c) void {
@@ -72,7 +93,10 @@ pub fn syscall(code: anytype, args: anytype) linksection(".userspace") i32 {
           [_] "{esi}" (_args.esi),
           [_] "{edi}" (_args.edi),
     ));
-    if (ebx != 0) return -1;
+    // The kernel returns the result in eax and the errno in ebx. Fold that into the
+    // usual negative-errno convention so callers keep a single value to test, without
+    // losing which error it was.
+    if (ebx != 0) return -@as(i32, @intCast(ebx));
     return res;
 }
 
@@ -291,6 +315,46 @@ export fn userland_io() linksection(".userspace") void {
     _ = syscall(.truncate, .{ "/bonjour", 10 });
     putstr_fd(fd, "BBBBBBBBBBBBBBBBBBBBBB\n");
     _ = syscall(.exit, .{0});
+}
+
+/// demo execve <path> [args...]
+///
+/// Unlike the other demos this one needs its own entry block, so it enters naked:
+/// the block is addressed through esp, and a normal prologue has already moved it.
+export fn userland_execve() linksection(".userspace") callconv(.naked) noreturn {
+    asm volatile (
+        \\ mov %esp, %ecx
+        \\ push %ecx
+        \\ call demo_execve
+    );
+}
+
+export fn demo_execve(sp: [*]const usize) linksection(".userspace") callconv(.c) noreturn {
+    // sysv entry block: argc, argv[argc], NULL, envp[], NULL, auxv
+    const argc = sp[0];
+    const argv: [*]const ?[*:0]const u8 = @ptrCast(sp + 1);
+    const envp: [*:null]const ?[*:0]const u8 = @ptrCast(sp + 2 + argc);
+
+    if (argc < 2) {
+        putstr("usage: demo execve <path> [args...]\n");
+        _ = syscall(.exit, .{1});
+        unreachable;
+    }
+
+    // Our own argv[0] is the demo name, so hand the image argv[1..]: it gets the path
+    // as its argv[0], like a shell would pass it.
+    const err = syscall(.execve, .{
+        argv[1].?,
+        @as([*:null]const ?[*:0]const u8, @ptrCast(argv + 1)),
+        envp,
+    });
+
+    // execve only comes back when it failed
+    putstr("execve failed, errno ");
+    putnbr(-err);
+    putstr("\n");
+    _ = syscall(.exit, .{1});
+    unreachable;
 }
 
 /// Sessions and the controlling terminal, POSIX 11.1.3, from userspace. The


### PR DESCRIPTION
Split so that failure is harmless: prepare_exec reads and validates the image and copies argv and envp into kernel memory, touching no task, so an error leaves the caller intact. commit_exec cannot fail and does not come back, it resets the kernel stack its caller runs on.

Ring 3 is now reached through prepare_entry and iret_to, which lay out the SysV block the same way for a demo as for a loaded image. call_userspace, which jumped to an entry point with an empty stack, is gone.

execve is not POSIX yet, and #! panics rather than being honoured.