### PR TITLE
signals on userspace exceptions

### DIFF
--- a/src/interrupts.zig
+++ b/src/interrupts.zig
@@ -343,18 +343,60 @@ pub const Handler = extern union {
     }
 };
 
+fn exception_to_cause(e: Exceptions) signal.Cause {
+    return switch (e) {
+        .DivisionError => .{ .fpe = .INTDIV },
+        .x87FloatingPointException,
+        .SIMDFloatingPointException,
+        .DeviceNotAvailable,
+        => .{ .kernel = .SIGFPE },
+        .Debug => .{ .trap = .TRACE },
+        .Breakpoint => .{ .trap = .BRKPT },
+        .InvalidOpcode => .{ .ill = .ILLOPN },
+        .AlignmentCheck => .{ .bus = .ADRALN },
+        .Overflow,
+        .BoundRangeExceeded,
+        .InvalidTSS,
+        .SegmentNotPresent,
+        .StackSegmentFault,
+        .GeneralProtectionFault,
+        .PageFault,
+        => .{ .kernel = .SIGSEGV },
+        else => .{ .kernel = .SIGILL },
+    };
+}
+
+fn user_exception(comptime id: u8, frame: InterruptFrame) bool {
+    if (frame.iret.cs.privilege != .User or !scheduler.is_initialized())
+        return false;
+
+    const e = @as(Exceptions, @enumFromInt(id));
+    const cause = exception_to_cause(e);
+    const task = scheduler.get_current_task();
+    std.log.warn("task {d}: exception {d} ({s}) at 0x{x:0>8}, sending {s}", .{
+        task.pid, id, @tagName(e), frame.iret.ip, @tagName(cause.signo()),
+    });
+    var info = signal.siginfo_t.init(cause);
+    info.si_pid = 0;
+    info.si_addr = @ptrFromInt(frame.iret.ip);
+    task.send_signal(info);
+    return true;
+}
+
 pub fn default_handler(
     comptime id: u8,
     comptime t: enum { except, except_err, irq, interrupt },
 ) Handler {
     const handlers = struct {
-        pub fn exception(_: InterruptFrame) void {
+        pub fn exception(frame: InterruptFrame) void {
+            if (user_exception(id, frame)) return;
             const e = @as(Exceptions, @enumFromInt(id));
             std.log.err("exception {d} ({s}) unhandled", .{ id, @tagName(e) });
         }
-        pub fn exception_err(_: InterruptFrame) void {
+        pub fn exception_err(frame: InterruptFrame) void {
+            if (user_exception(id, frame)) return;
             const e = @as(Exceptions, @enumFromInt(id));
-            std.log.err("exception {d} ({s}) unhandled: 0x{x}", .{ id, @tagName(e), 0 });
+            std.log.err("exception {d} ({s}) unhandled: 0x{x}", .{ id, @tagName(e), frame.code });
         }
         pub fn irq(_: InterruptFrame) void {
             const _id = pic.get_irq_from_interrupt_id(id);

--- a/src/memory/page_fault.zig
+++ b/src/memory/page_fault.zig
@@ -7,6 +7,7 @@ const mapping = @import("mapping.zig");
 const scheduler = @import("../task/scheduler.zig");
 const InterruptFrame = @import("../interrupts.zig").InterruptFrame;
 const TaskDescriptor = @import("../task/task.zig").TaskDescriptor;
+const signal = @import("../task/signal.zig");
 
 const PageFault = struct {
     present: bool,
@@ -71,13 +72,11 @@ fn kernel_page_fault(fault: PageFault) void {
 }
 
 fn segmentation_fault(task: *TaskDescriptor, fault: PageFault) void {
-    task.send_signal(.{
-        .si_signo = .{ .valid = .SIGSEGV },
-        .si_code = if (fault.present) .SEGV_ACCERR else .SEGV_MAPERR,
-        .si_pid = 0,
-        .si_addr = fault.faulting_address,
-        // todo set more fields of siginfo
-    });
+    var info = signal.siginfo_t.init(.{ .segv = if (fault.present) .ACCERR else .MAPERR });
+    info.si_pid = 0;
+    info.si_addr = fault.faulting_address;
+    // todo set more fields of siginfo
+    task.send_signal(info);
 }
 
 fn user_page_fault(fault: PageFault) void {

--- a/src/syscall/kill.zig
+++ b/src/syscall/kill.zig
@@ -10,27 +10,21 @@ pub fn do(pid: task.TaskDescriptor.Pid, id: signal.Id) !void {
     if (pid > 0) {
         const descriptor = task_set.get_task_descriptor(pid) orelse return Errno.ESRCH;
         // todo permisssion
-        descriptor.send_signal(.{
-            .si_signo = .{ .valid = id },
-            .si_code = .SI_USER,
-            .si_pid = scheduler.get_current_task().pid,
-            // todo set more fields of siginfo
-        });
+        var info = signal.siginfo_t.init(.{ .user = id });
+        info.si_pid = scheduler.get_current_task().pid;
+        // todo set more fields of siginfo
+        descriptor.send_signal(info);
     } else if (pid == 0) {
         const pgid = scheduler.get_current_task().pgid;
-        if (task_set.send_signal_to_group(pgid, .{
-            .si_signo = .{ .valid = id },
-            .si_code = .SI_USER,
-            .si_pid = scheduler.get_current_task().pid,
-        }) == 0) return Errno.ESRCH;
+        var info = signal.siginfo_t.init(.{ .user = id });
+        info.si_pid = scheduler.get_current_task().pid;
+        if (task_set.send_signal_to_group(pgid, info) == 0) return Errno.ESRCH;
     } else if (pid == -1) {
         // todo: every process for which the calling process has  per-
         // mission to send signals, except for process 1
     } else { // pid < -1
-        if (task_set.send_signal_to_group(-pid, .{
-            .si_signo = .{ .valid = id },
-            .si_code = .SI_USER,
-            .si_pid = scheduler.get_current_task().pid,
-        }) == 0) return Errno.ESRCH;
+        var info = signal.siginfo_t.init(.{ .user = id });
+        info.si_pid = scheduler.get_current_task().pid;
+        if (task_set.send_signal_to_group(-pid, info) == 0) return Errno.ESRCH;
     }
 }

--- a/src/task/session.zig
+++ b/src/task/session.zig
@@ -6,6 +6,7 @@ const std = @import("std");
 
 const TaskDescriptor = @import("task.zig").TaskDescriptor;
 const TtyStruct = @import("../tty/TtyStruct.zig");
+const signal = @import("signal.zig");
 
 const allocator = @import("../memory.zig").smallAlloc.allocator();
 
@@ -57,11 +58,10 @@ pub fn hangup(self: *Self) void {
     const terminal = self.ctty orelse return;
 
     if (terminal.foreground_pgid) |pgid| {
-        _ = @import("task_set.zig").send_signal_to_group(pgid, .{
-            .si_signo = .{ .valid = .SIGHUP },
-            .si_code = .SI_KERNEL,
-            .si_pid = 0,
-        });
+        _ = @import("task_set.zig").send_signal_to_group(
+            pgid,
+            signal.siginfo_t.init(.{ .kernel = .SIGHUP }),
+        );
     }
     self.disown(terminal);
 }

--- a/src/task/signal.zig
+++ b/src/task/signal.zig
@@ -58,24 +58,78 @@ pub const Id = enum(u32) {
     SIGXFSZ = 31,
 };
 
-pub const Code = enum(u32) {
-    SI_USER,
-    SEGV_ACCERR,
-    SEGV_MAPERR,
-    /// Raised by the kernel rather than by a process: a terminal generating a
-    /// signal from a control character has no sender to name.
-    SI_KERNEL,
+pub const Ill = enum(i32) {
+    ILLOPC = 1,
+    ILLOPN = 2,
+    ILLADR = 3,
+    ILLTRP = 4,
+    PRVOPC = 5,
+    PRVREG = 6,
+    COPROC = 7,
+    BADSTK = 8,
+};
+
+pub const Fpe = enum(i32) {
+    INTDIV = 1,
+    INTOVF = 2,
+    FLTDIV = 3,
+    FLTOVF = 4,
+    FLTUND = 5,
+    FLTRES = 6,
+    FLTINV = 7,
+    FLTSUB = 8,
+};
+
+pub const Segv = enum(i32) { MAPERR = 1, ACCERR = 2 };
+pub const Bus = enum(i32) { ADRALN = 1, ADRERR = 2, OBJERR = 3 };
+pub const Trap = enum(i32) { BRKPT = 1, TRACE = 2 };
+
+pub const Cause = union(enum) {
+    user: Id,
+    kernel: Id,
+    ill: Ill,
+    fpe: Fpe,
+    segv: Segv,
+    bus: Bus,
+    trap: Trap,
+
+    pub fn signo(self: Cause) Id {
+        return switch (self) {
+            .user, .kernel => |id| id,
+            .ill => .SIGILL,
+            .fpe => .SIGFPE,
+            .segv => .SIGSEGV,
+            .bus => .SIGBUS,
+            .trap => .SIGTRAP,
+        };
+    }
+
+    pub fn code(self: Cause) i32 {
+        return switch (self) {
+            .user => 0,
+            .kernel => 0x80,
+            inline .ill, .fpe, .segv, .bus, .trap => |c| @intFromEnum(c),
+        };
+    }
 };
 
 pub const siginfo_t = extern struct {
     si_signo: Signo = Signo.invalid,
-    si_code: Code = undefined,
+    si_code: i32 = undefined,
     si_errno: u32 = undefined,
     si_pid: TaskDescriptor.Pid = undefined, // todo pid type
     // si_uid
     si_addr: paging.VirtualPtr = undefined,
     si_status: u32 = undefined,
     // si_value : sigval
+
+    pub fn init(cause: Cause) siginfo_t {
+        return .{
+            .si_signo = Signo.make(cause.signo()),
+            .si_code = cause.code(),
+        };
+    }
+
     pub const Signo = packed union {
         valid: Id,
         null: Monostate(u32, 0),

--- a/src/tty/TtyStruct.zig
+++ b/src/tty/TtyStruct.zig
@@ -4,6 +4,7 @@
 const std = @import("std");
 
 const termios = @import("termios.zig");
+const signal = @import("../task/signal.zig");
 const TtyDriver = @import("TtyDriver.zig");
 const InputBuffer = @import("InputBuffer.zig");
 const Pid = @import("../task/task.zig").TaskDescriptor.Pid;
@@ -186,11 +187,7 @@ pub fn hangup(self: *Self) void {
 
     if (self.session) |session| {
         if (@import("../task/task_set.zig").get_task_descriptor(session.sid)) |leader| {
-            leader.send_signal(.{
-                .si_signo = .{ .valid = .SIGHUP },
-                .si_code = .SI_KERNEL,
-                .si_pid = 0,
-            });
+            leader.send_signal(signal.siginfo_t.init(.{ .kernel = .SIGHUP }));
         }
     }
 

--- a/src/tty/job_control.zig
+++ b/src/tty/job_control.zig
@@ -19,11 +19,7 @@ fn would_be_lost(task: *TaskDescriptor, id: signal.Id) bool {
 }
 
 fn raise(task: *TaskDescriptor, id: signal.Id) void {
-    _ = task_set.send_signal_to_group(task.pgid, .{
-        .si_signo = .{ .valid = id },
-        .si_code = .SI_KERNEL,
-        .si_pid = 0,
-    });
+    _ = task_set.send_signal_to_group(task.pgid, signal.siginfo_t.init(.{ .kernel = id }));
 }
 
 /// Whether this terminal governs the caller at all, and whether the caller is

--- a/src/tty/ldisc/n_tty.zig
+++ b/src/tty/ldisc/n_tty.zig
@@ -54,11 +54,7 @@ fn raise_signal(tty: *TtyStruct, c: u8, id: signal.Id) void {
     if (!tty.config.c_lflag.NOFLSH) tty.input_buffer.clear();
 
     const pgid = tty.foreground_pgid orelse return;
-    _ = task_set.send_signal_to_group(pgid, .{
-        .si_signo = .{ .valid = id },
-        .si_code = .SI_KERNEL,
-        .si_pid = 0,
-    });
+    _ = task_set.send_signal_to_group(pgid, signal.siginfo_t.init(.{ .kernel = id }));
 }
 
 /// The START and STOP characters, POSIX 11.2.2 IXON. They control output and


### PR DESCRIPTION
A faulting ring 3 task took the kernel down with it. It now gets the matching signal, delivered on the way back out; returning without one would iret straight onto the faulting instruction and fault forever. Exceptions POSIX names a code for get it, the rest fall back to SI_KERNEL.

si_code becomes a Cause union rather than a flat enum, so a code cannot be paired with a signal it does not belong to: 1 means SEGV_MAPERR under SIGSEGV and ILL_ILLOPC under SIGILL. The values are userspace ABI and match mlibc's abi-bits. Our own kernel-raised signals move to its .kernel variant.