### PR TITLE
ADD(syscall): set_thread_area, per-task userspace TLS via %gs

### DIFF
--- a/src/cpu.zig
+++ b/src/cpu.zig
@@ -255,6 +255,14 @@ pub inline fn load_segments(comptime code: Selector, data: Selector, stack: Sele
     );
 }
 
+pub inline fn load_gs(selector: Selector) void {
+    asm volatile (
+        \\ movw %[selector], %gs
+        :
+        : [selector] "{ax}" (selector),
+    );
+}
+
 pub inline fn halt() void {
     asm volatile ("hlt");
 }

--- a/src/gdt.zig
+++ b/src/gdt.zig
@@ -130,7 +130,29 @@ var GDT = [_]u64{
         }),
     }),
     0, // TSS entry
+    0, // reserved: double fault TSS, from the stack overflow branch
+    0, // user TLS entry, set per task via set_tls()
 };
+
+pub const tls_index = 9;
+
+pub fn set_tls(base: u32) void {
+    GDT[tls_index] = encode_gdt(.{
+        .base = base,
+        .limit = 0x000FFFFF,
+        .flags = @bitCast(flag_type{
+            .long_mode = false,
+            .size = true,
+            .granularity = true,
+        }),
+        .access_byte = @bitCast(access_byte_type{
+            .type = true,
+            .present = true,
+            .privilege = cpu.PrivilegeLevel.User,
+            .readable_writable = true,
+        }),
+    });
+}
 
 pub const GDTR = packed struct(u48) {
     size: u16,

--- a/src/syscall/fork.zig
+++ b/src/syscall/fork.zig
@@ -33,6 +33,7 @@ pub fn do_raw() void {
     new_task.files = current_task.files.clone();
     new_task.clone_vm(current_task) catch @panic("todo errno");
     new_task.ucontext = current_task.ucontext;
+    new_task.tls_base = current_task.tls_base;
 
     new_task.ucontext.uc_mcontext.eax = 0;
     new_task.ucontext.uc_mcontext.ebx = 0;

--- a/src/syscall/set_thread_area.zig
+++ b/src/syscall/set_thread_area.zig
@@ -1,0 +1,13 @@
+pub const Id = 20;
+const Errno = @import("../errno.zig").Errno;
+const scheduler = @import("../task/scheduler.zig");
+const task = @import("../task/task.zig");
+const paging = @import("../memory/paging.zig");
+
+pub fn do(base: usize) !void {
+    if (base == 0 or base >= paging.high_half)
+        return Errno.EINVAL;
+    const current_task = scheduler.get_current_task();
+    current_task.tls_base = base;
+    task.apply_tls(current_task);
+}

--- a/src/task/task.zig
+++ b/src/task/task.zig
@@ -81,6 +81,8 @@ pub const TaskDescriptor = struct {
 
     esp: u32 = undefined,
 
+    tls_base: ?u32 = null,
+
     ucontext: ucontext.ucontext_t = .{},
 
     // scheduling
@@ -543,6 +545,7 @@ pub const TaskDescriptor = struct {
         scheduler.set_current_task(self);
         gdt.tss.esp0 = @as(usize, @intFromPtr(&self.stack)) + self.stack.len;
         gdt.flush();
+        apply_tls(self);
         scheduler.exit_critical();
         exit(function(data));
     }
@@ -555,6 +558,13 @@ pub const TaskDescriptor = struct {
         self.cwd = new_dir.get_ref();
     }
 };
+
+pub fn apply_tls(t: *TaskDescriptor) void {
+    if (t.tls_base) |base| {
+        gdt.set_tls(base);
+        cpu.load_gs(.{ .index = gdt.tls_index, .table = .GDT, .privilege = .User });
+    }
+}
 
 pub noinline fn switch_to_task_opts(prev: *TaskDescriptor, next: *TaskDescriptor) void {
     asm volatile (
@@ -593,6 +603,7 @@ pub fn switch_to_task(prev: *TaskDescriptor, next: *TaskDescriptor) void {
 
     gdt.tss.esp0 = @as(usize, @intFromPtr(&next.stack)) + next.stack.len;
     gdt.flush();
+    apply_tls(next);
 
     return switch_to_task_opts(prev, next);
 }


### PR DESCRIPTION
mlibc's mandatory sys_tcb_set needs a thread pointer, held in %gs on i386. The syscall stores the TCB base in TaskDescriptor.tls_base and loads it into a GDT entry (data RW, DPL 3).

apply_tls refreshes that entry and reloads %gs on every context switch and task start: the segment register caches the descriptor, so updating the GDT in place would leave the previous task's base active. fork clones tls_base.